### PR TITLE
Make visualizations work with arbitrary-sized graphs

### DIFF
--- a/core/package.yaml
+++ b/core/package.yaml
@@ -71,6 +71,7 @@ dependencies:
     - time
     - time-locale-compat
     - typelevel
+    - uuid
     - vector
     - ansi-terminal
     - text-processing

--- a/core/src-libs/Luna/Test/IR/Runner.hs
+++ b/core/src-libs/Luna/Test/IR/Runner.hs
@@ -16,6 +16,8 @@ import Data.Aeson                           (encode)
 import System.Log.Logger.Format (nestedColorFormatter, bulletNestingFormatter)
 import Control.Monad.Raise
 import System.Environment (lookupEnv)
+import qualified Data.UUID.V4 as UUID
+import qualified Data.UUID    as UUID
 import Control.Monad.State.Dependent
 
 data TestPass
@@ -52,5 +54,10 @@ withVis m = do
     let cfg = ByteString.unpack $ encode vis
     when (not . null $ vis ^. Vis.steps) $ do
         env <- liftIO $ lookupEnv "DEBUGVIS"
-        if isJust env then void $ liftIO $ openBrowser $ "http://localhost:8000?cfg=" <> cfg else return ()
+        case env of
+            Just path -> liftIO $ do
+                uid <- UUID.toString <$> UUID.nextRandom
+                writeFile (path ++ "/" ++ uid ++ ".json") cfg
+                void $ openBrowser $ "http://localhost:8000?cfgPath=" <> uid
+            _ -> return ()
     return p

--- a/core/src/OCI/IR/Repr/Vis.hs
+++ b/core/src/OCI/IR/Repr/Vis.hs
@@ -48,6 +48,7 @@ visNodeWith nodeLabeler edgeLabeler t = do
     value  <- matchExpr t $ return . \case
         String    s   -> "'" <> s <> "'"
         Number    n   -> show n
+        Acc       t n -> "Acc "  <> show n
         Var       n   -> "Var "  <> show n
         Cons      n _ -> "Cons " <> show n
         FieldLens p   -> "Lens " <> show p


### PR DESCRIPTION
This changes how IR vis is used.
Before we were putting the graph description straight into the URL. This broke on any graph larger than a dozen nodes.
Now the visualizer puts the data in a file (in a location specified as a value of the `DEBUGVIS` variable, about which contents we didn't care before) and passes the name of this file in the URL. This is accompanied by this PR in IRVis: https://github.com/luna/irvis/pull/1