### PR TITLE
Fix the definition of HTTP HEAD method.

### DIFF
--- a/stdlib/Std/src/HTTP.luna
+++ b/stdlib/Std/src/HTTP.luna
@@ -195,8 +195,8 @@ class Http:
         defaultHttpRequest uri
 
     ## Create a basic Http HEAD request for a given uri.
-    def head uri :
-        defaultHttpRequest uri . setMethod HEAD . setBody body
+    def head uri:
+        defaultHttpRequest uri . setMethod HEAD
 
     ## Create an Http POST request for a given uri and body.
     ## The body can be anything that provides a `toBinary` method,


### PR DESCRIPTION
Previous version did not compile due to an obvious mistake.