### PR TITLE
Use Scientific instead of Real inside JSONs

### DIFF
--- a/stdlib/Std/src/Base.luna
+++ b/stdlib/Std/src/Base.luna
@@ -27,7 +27,7 @@ native class Int:
     ## Alias for `toText`, for the purpose of pretty printing the number.
     def shortRep: self.toText
     ## JSON representation of an integer.
-    def toJSON: JSONNumber self.toReal
+    def toJSON: JSONNumber (Scientific self 0)
 
     ## Returns a TimeInterval with the length of `self` miliseconds.
     def miliseconds: primIntMiliseconds self
@@ -122,7 +122,7 @@ native class Real:
     ## Displays a number as text.
     def shortRep: self.toText
     ## Converts a number to `JSON`.
-    def toJSON: JSONNumber self
+    def toJSON: JSONNumber (primRealToScientific self)
 
 ## The mathematical constant π = 3.14159265359.
 def pi: 3.14159265359
@@ -974,11 +974,24 @@ class Map k v:
                     l' = l . delete key
                     Map._bin k v l' r . _balanceR
 
+class Scientific:
+    coefficient :: Int
+    exponent :: Int
+
+    def toText: case self.exponent >= 0 of
+        True:
+            coeff = self.coefficient.toText
+            1 . upto self.exponent . each (_: "0") . prepend coeff . makeText ""
+        False:
+            self . toReal . toText
+
+    def toReal:
+        self.coefficient.toReal * (10.0 ^ self.exponent.toReal)
 
 ## Class representing JSON objects.
 class JSON:
     JSON
-    JSONNumber Real
+    JSONNumber Scientific
     JSONString Text
     JSONBool   Bool
     JSONArray  (List JSON)
@@ -998,7 +1011,7 @@ class JSON:
 
     ## Dumps a `JSON` structure into a `Text` object.
     def toText: case self of
-        JSONNumber d: d.shortRep
+        JSONNumber d: d.toText
         JSONString s: s.escapeJSON
         JSONArray  l: "[" + (l . map (x : x.toText) . intersperse "," . fold "" (+)) + "]"
         JSONBool   b: case b of
@@ -1010,6 +1023,7 @@ class JSON:
     ## Dumps a `JSON` structure into a `Text` object.
     def render: self.toText
 
+    def toBinary: self.toText.toBinary
     ## Short text representation for a `JSON` object.
     def shortRep: self.render
 
@@ -1050,12 +1064,12 @@ class JSON:
 
     ## Returns a `Real` assuming the `JSON` represents a number. Throws an error otherwise.
     def asReal: case self of
-        JSONNumber a: a
+        JSONNumber a: a.toReal
         other: throw "JSON.asReal: not a number."
 
     ## Returns a `Bool` assuming the `JSON` represents a boolean. Throws an error otherwise.
     def asBool: case self of
-        JSONNumber a: a
+        JSONBool a: a
         other: throw "JSON.asBool: not a boolean."
 
     ## Returns a list of `JSON` object assuming the `JSON` represents an array. Throws an error otherwise.
@@ -1075,12 +1089,12 @@ class JSON:
 
     ## Returns `Just` a `Real` assuming the `JSON` represents a number. Throws an error otherwise.
     def safeAsReal: case self of
-        JSONNumber a: Just a
+        JSONNumber a: Just a.toReal
         other: Nothing
 
     ## Returns `Just` a `Bool` assuming the `JSON` represents a boolean. Throws an error otherwise.
     def safeAsBool: case self of
-        JSONNumber a: Just a
+        JSONBool a: Just a
         other: Nothing
 
     ## Returns `Just` a list of `JSON` object assuming the `JSON` represents an array. Throws an error otherwise.

--- a/stdlib/src/Luna/Prim/Base.hs
+++ b/stdlib/src/Luna/Prim/Base.hs
@@ -18,7 +18,7 @@ import qualified Data.HashMap.Lazy           as HM
 import           Data.Map                    (Map)
 import qualified Data.Map                    as Map
 import qualified Data.Map.Base               as IMap
-import           Data.Scientific             (toRealFloat)
+import           Data.Scientific             (toRealFloat, Scientific, coefficient, base10Exponent, fromFloatDigits)
 import           Data.Text.Lazy              (Text)
 import qualified Data.Text.Lazy              as Text
 import qualified Data.Text.Lazy.Encoding     as Text
@@ -39,13 +39,14 @@ import           System.FilePath             (pathSeparator)
 
 primReal :: Imports -> IO (Map Name Function)
 primReal imps = do
-    (doubleIntDoubleAssumptions, doubleIntDouble) <- makeTypePure ["Real", "Int"]  "Real"
-    (boxed3DoublesAssumptions,   boxed3Doubles)   <- makeTypePure ["Real", "Real"] "Real"
-    (double2BoolAssumptions,     double2Bool)     <- makeTypePure ["Real", "Real"] "Bool"
-    (double2TextAssumptions,     double2text)     <- makeTypePure ["Real"]         "Text"
-    (double2IntAssumptions,      double2int)      <- makeTypePure ["Real"]         "Int"
-    (double2JSONAssumptions,     double2JSON)     <- makeTypePure ["Real"]         "JSON"
-    (double2DoubleAssumptions,   double2Double)   <- makeTypePure ["Real"]         "Real"
+    (doubleIntDoubleAssumptions,   doubleIntDouble)   <- makeTypePure ["Real", "Int"]  "Real"
+    (boxed3DoublesAssumptions,     boxed3Doubles)     <- makeTypePure ["Real", "Real"] "Real"
+    (double2BoolAssumptions,       double2Bool)       <- makeTypePure ["Real", "Real"] "Bool"
+    (double2TextAssumptions,       double2text)       <- makeTypePure ["Real"]         "Text"
+    (double2IntAssumptions,        double2int)        <- makeTypePure ["Real"]         "Int"
+    (double2JSONAssumptions,       double2JSON)       <- makeTypePure ["Real"]         "JSON"
+    (double2DoubleAssumptions,     double2Double)     <- makeTypePure ["Real"]         "Real"
+    (double2ScientificAssumptions, double2Scientific) <- makeTypePure ["Real"]         "Scientific"
 
     let plusVal     = toLunaValue imps ((+)          :: Double -> Double -> Double)
         timeVal     = toLunaValue imps ((*)          :: Double -> Double -> Double)
@@ -81,6 +82,8 @@ primReal imps = do
         sqrtVal     = toLunaValue imps (sqrt :: Double -> Double)
         logVal      = toLunaValue imps (log  :: Double -> Double)
         uminusVal   = toLunaValue imps ((* (-1)) :: Double -> Double)
+
+        toScientificVal = toLunaValue imps (fromFloatDigits :: Double -> Scientific)
     return $ Map.fromList [ ("primRealAdd",      Function boxed3Doubles   plusVal    boxed3DoublesAssumptions  )
                           , ("primRealMultiply", Function boxed3Doubles   timeVal    boxed3DoublesAssumptions  )
                           , ("primRealSubtract", Function boxed3Doubles   minusVal   boxed3DoublesAssumptions  )
@@ -118,6 +121,8 @@ primReal imps = do
                           , ("primRealLn",       Function double2Double   logVal     double2DoubleAssumptions  )
                           , ("primRealSqrt",     Function double2Double   sqrtVal    double2DoubleAssumptions  )
                           , ("primRealNegate",   Function double2Double   uminusVal  double2DoubleAssumptions  )
+
+                          , ("primRealToScientific", Function double2Scientific toScientificVal double2ScientificAssumptions)
                           ]
 
 primInt :: Imports -> IO (Map Name Function)
@@ -362,11 +367,15 @@ instance (ToLunaData a, ToLunaData b) => ToLunaData (IMap.Map a b) where
         constructorOf IMap.Tip             = Constructor "Tip" []
         constructorOf (IMap.Bin s k v l r) = Constructor "Bin" [toLunaData imps $ integer s, toLunaData imps k, toLunaData imps v, toLunaData imps l, toLunaData imps r]
 
+type instance RuntimeRepOf Scientific = AsClass "Scientific" Scientific
+instance ToLunaObject Scientific where
+    toConstructor imps s = Constructor "Scientific" [toLunaData imps $ coefficient s, toLunaData imps $ integer $ base10Exponent s]
+
 type instance RuntimeRepOf Aeson.Value = AsClass "JSON" Aeson.Value
 instance ToLunaObject Aeson.Value where
     toConstructor imps (Aeson.Array  a) = Constructor "JSONArray"  [toLunaData imps . toList $ a]
     toConstructor imps (Aeson.String a) = Constructor "JSONString" [toLunaData imps (convert a :: Text)]
-    toConstructor imps (Aeson.Number a) = Constructor "JSONNumber" [toLunaData imps (toRealFloat a :: Double)]
+    toConstructor imps (Aeson.Number a) = Constructor "JSONNumber" [toLunaData imps a]
     toConstructor imps (Aeson.Bool   a) = Constructor "JSONBool"   [toLunaData imps a]
     toConstructor imps  Aeson.Null      = Constructor "JSONNull"   []
     toConstructor imps (Aeson.Object a) = Constructor "JSONObject" [toLunaData imps $ (Map.mapKeys convert $ Map.fromList $ HM.toList a :: Map Text Aeson.Value)]


### PR DESCRIPTION
Because some endpoints require integers to be rendered as integers.