### PR TITLE
Fix local bin path

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,7 @@ ghc-options:
         -fconstraint-solver-iterations=100
     $everything:
         -fconstraint-solver-iterations=100
-local-bin-path: ../dist/bin/public/luna
+local-bin-path: dist/bin/public/luna
 packages:
     - location: shell
     - location: core


### PR DESCRIPTION
The `stack.yaml` is now a level higher, and the current version puts luna outside of the repository.