### PR TITLE
Proper resolution of projects in local_libs

### DIFF
--- a/project/src/Luna/Project.hs
+++ b/project/src/Luna/Project.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Luna.Project where
 
 import Luna.Prelude hiding (FilePath)
@@ -12,8 +13,10 @@ import           Control.Arrow          ((&&&))
 import           Control.Exception.Safe (try, tryAny)
 import           Data.Bimap             (Bimap)
 import qualified Data.Bimap             as Bimap
+import           Path                   (Path, Abs, Rel, File, Dir, (</>))
 import qualified Path                   as Path
 import qualified System.Directory       as Dir
+import           System.Environment     (getEnv)
 import qualified System.FilePath        as FP
 import qualified System.FilePath.Find   as Find
 
@@ -22,7 +25,7 @@ import qualified System.FilePath.Find   as Find
 -- === Project === --
 ---------------------
 
-projectSourcesForFile :: Path.Path Path.Abs Path.File -> IO (Maybe (Bimap (Path.Path Path.Abs Path.File) QualName))
+projectSourcesForFile :: Path Abs File -> IO (Maybe (Bimap (Path Abs File) QualName))
 projectSourcesForFile file = do
     projectRoot <- findProjectRootForFile file
     mapM findProjectSources projectRoot
@@ -30,75 +33,87 @@ projectSourcesForFile file = do
 lunaProjectExt :: String
 lunaProjectExt = ".lunaproject"
 
-findProjectRootForFile :: Path.Path Path.Abs Path.File -> IO (Maybe (Path.Path Path.Abs Path.Dir))
+findProjectRootForFile :: Path Abs File -> IO (Maybe (Path Abs Dir))
 findProjectRootForFile = findProjectRoot . Path.parent
 
-findProjectFileForFile :: Path.Path Path.Abs Path.File -> IO (Maybe (Path.Path Path.Abs Path.File))
+data ProjectNotFoundException = ProjectNotFoundException (Path Abs File)
+    deriving Show
+
+instance Exception ProjectNotFoundException where
+    displayException (ProjectNotFoundException file) =
+        "File \"" <> Path.toFilePath file <> "\" is not a part of any project."
+
+projectRootForFile :: Path Abs File -> IO (Path Abs Dir)
+projectRootForFile file = do
+    maybeRoot <- findProjectRoot $ Path.parent file
+    maybe (throwM (ProjectNotFoundException file)) return maybeRoot
+
+findProjectFileForFile :: Path Abs File -> IO (Maybe (Path Abs File))
 findProjectFileForFile = findProjectFile . Path.parent
 
-getRelativePathForModule :: Path.Path Path.Abs Path.File -> Path.Path Path.Abs Path.File -> IO (Maybe (Path.Path Path.Rel Path.File))
+getRelativePathForModule :: Path Abs File -> Path Abs File -> IO (Maybe (Path Rel File))
 getRelativePathForModule projectFile = fmap eitherToMaybe . try . Path.stripProperPrefix (Path.parent projectFile) where
-    eitherToMaybe :: Either Path.PathException (Path.Path Path.Rel Path.File) -> Maybe (Path.Path Path.Rel Path.File)
+    eitherToMaybe :: Either Path.PathException (Path Rel File) -> Maybe (Path Rel File)
     eitherToMaybe = either (const Nothing) Just
 
-getLunaProjectsFromDir :: Path.Path Path.Abs Path.Dir -> IO [Path.Path Path.Abs Path.File]
+getLunaProjectsFromDir :: Path Abs Dir -> IO [Path Abs File]
 getLunaProjectsFromDir dir = do
     filesInDir <- Dir.listDirectory (Path.toFilePath dir)
     files      <- mapM Path.parseRelFile filesInDir
-    return . map (dir Path.</>) $ filter (\file -> Path.fileExtension file == lunaProjectExt) files
+    return . map (dir </>) $ filter (\file -> Path.fileExtension file == lunaProjectExt) files
 
-findProjectFile :: Path.Path Path.Abs Path.Dir -> IO (Maybe (Path.Path Path.Abs Path.File))
+findProjectFile :: Path Abs Dir -> IO (Maybe (Path Abs File))
 findProjectFile dir = getLunaProjectsFromDir dir >>= \case
     [] -> let parentDir = Path.parent dir in
         if parentDir == dir then return Nothing else findProjectFile parentDir
     [projectFile] -> return $ Just projectFile
     _             -> return Nothing
 
-findProjectRoot :: Path.Path Path.Abs Path.Dir -> IO (Maybe (Path.Path Path.Abs Path.Dir))
+findProjectRoot :: Path Abs Dir -> IO (Maybe (Path Abs Dir))
 findProjectRoot dir = getLunaProjectsFromDir dir >>= \case
     [] -> let parentDir = Path.parent dir in
         if parentDir == dir then return Nothing else findProjectRoot parentDir
     [projectFile] -> return $ Just dir
     _             -> return Nothing
 
-getProjectName :: Path.Path Path.Abs Path.Dir -> Name
+getProjectName :: Path Abs Dir -> Name
 getProjectName = convert . FP.takeBaseName . FP.takeDirectory . Path.toFilePath
 
 lunaFileExt :: String
 lunaFileExt = ".luna"
 
-mkQualName :: Path.Path Path.Rel Path.File -> QualName
-mkQualName file = qualName
+mkQualName :: Name -> Path Rel File -> QualName
+mkQualName projectName file = qualName
     where
-        qualName        = Qual.mkQualName (convert path) (convert moduleName)
+        qualName        = Qual.mkQualName (convert (convert projectName : path)) (convert moduleName)
         path            = filter (/= ".") $ FP.splitDirectories dir
         moduleName      = FP.dropExtensions filename
         (dir, filename) = FP.splitFileName (Path.toFilePath file)
 
-assignQualName :: Path.Path Path.Abs Path.Dir -> Path.Path Path.Abs Path.File -> (Path.Path Path.Abs Path.File, QualName)
-assignQualName srcDir filePath = (filePath, qualName)
+assignQualName :: Path Abs Dir -> Path Abs File -> (Path Abs File, QualName)
+assignQualName project filePath = (filePath, qualName)
     where
-        qualName         = mkQualName relFileName
-        Just relFileName = Path.stripDir srcDir filePath
+        qualName         = mkQualName (getProjectName project) relFileName
+        Just relFileName = Path.stripDir (project </> sourceDirectory) filePath
 
-sourceDirectory :: Path.Path Path.Rel Path.Dir
+sourceDirectory :: Path Rel Dir
 sourceDirectory = $(Path.mkRelDir "src")
 
-findProjectSources :: Path.Path Path.Abs Path.Dir -> IO (Bimap (Path.Path Path.Abs Path.File) QualName)
+findProjectSources :: Path Abs Dir -> IO (Bimap (Path Abs File) QualName)
 findProjectSources project = do
-    let srcDir            = project Path.</> sourceDirectory
+    let srcDir            = project </> sourceDirectory
         lunaFilePredicate = Find.extension Find.~~? lunaFileExt
     lunaFiles    <- Find.find Find.always lunaFilePredicate (Path.toFilePath srcDir)
     lunaFilesAbs <- mapM Path.parseAbsFile lunaFiles
-    let modules  = map (assignQualName srcDir) lunaFilesAbs
+    let modules  = map (assignQualName project) lunaFilesAbs
     return $ Bimap.fromList modules
 
-localLibsPath :: Path.Path Path.Rel Path.Dir
+localLibsPath :: Path Rel Dir
 localLibsPath = $(Path.mkRelDir "local_libs")
 
-listDependencies :: Path.Path Path.Abs Path.Dir -> IO [(Name, FP.FilePath)]
+listDependencies :: Path Abs Dir -> IO [(Name, FP.FilePath)]
 listDependencies projectSrc = do
-    let lunaModules     = projectSrc Path.</> localLibsPath
+    let lunaModules     = projectSrc </> localLibsPath
         lunaModulesPath = Path.toFilePath lunaModules
     dependencies <- tryAny $ Dir.listDirectory lunaModulesPath
     case dependencies of
@@ -106,5 +121,17 @@ listDependencies projectSrc = do
         Right directDeps -> do
             indirectDeps <- forM directDeps $ \proj -> do
                 path <- Path.parseRelDir proj
-                listDependencies (lunaModules Path.</> path)
+                listDependencies (lunaModules </> path)
             return $ map (convert &&& (lunaModulesPath FP.</>)) directDeps <> concat indirectDeps
+
+projectImportPaths :: Path Abs Dir -> IO [(Name, FP.FilePath)]
+projectImportPaths projectRoot = do
+    lunaroot     <- Dir.canonicalizePath =<< getEnv lunaRootEnv
+    dependencies <- listDependencies projectRoot
+    let importPaths = ("Std", lunaroot <> "/Std/")
+                    : (getProjectName &&& Path.toFilePath) projectRoot
+                    : dependencies
+    return importPaths
+
+lunaRootEnv :: String
+lunaRootEnv = "LUNA_LIBS_PATH"

--- a/shell/src/Luna/Shell.hs
+++ b/shell/src/Luna/Shell.hs
@@ -126,7 +126,7 @@ stdlibPath = do
     exists <- doesDirectoryExist stdPath
     if exists
         then putStrLn $ "Found the standard library at: " <> stdPath
-        else die "Standard library not found. Set the " <> Project.lunaRootEnv <> " environment variable"
+        else die $ "Standard library not found. Set the " <> Project.lunaRootEnv <> " environment variable"
     return stdPath
 
 main :: IO ()
@@ -137,7 +137,7 @@ main = do
     stdPath      <- stdlibPath
     (_, std)     <- Project.prepareStdlib  (Map.fromList [("Std", stdPath)])
     dependencies <- Project.listDependencies mainPath
-    libs         <- Project.projectImportPaths mainPath
+    libs         <- Map.fromList <$> Project.projectImportPaths mainPath
     Right (_, imp) <- Project.requestModules libs [[mainName, "Main"]] std
     let mainFun = imp ^? Project.modules . ix [mainName, "Main"] . importedFunctions . ix "main" . Function.documentedItem
     case mainFun of

--- a/shell/src/Luna/Shell.hs
+++ b/shell/src/Luna/Shell.hs
@@ -107,7 +107,9 @@ formatError (CompileError txt reqStack stack) = Layout.nested (convert txt) </> 
     arisingStack  = Layout.nested (formatStack $ reverse stack)
     requiredStack = Layout.nested (formatStack reqStack)
     arisingBlock  = arisingFrom </> Layout.indented arisingStack
-    requiredBlock = if null reqStack then Layout.phantom else requiredBy  </> Layout.indented requiredStack
+    requiredBlock = if null reqStack
+                    then Layout.phantom
+                    else requiredBy  </> Layout.indented requiredStack
 
 formatErrors :: [CompileError] -> Doc Terminal.TermText
 formatErrors errs = foldl (<//>) mempty items where
@@ -118,15 +120,23 @@ stdlibPath :: IO FilePath
 stdlibPath = do
     env     <- Map.fromList <$> Env.getEnvironment
     exePath <- fst <$> splitExecutablePath
-    let (<</>>)        = (FilePath.</>)  -- purely for convenience, because </> is defined elswhere
-        parent         = let p = FilePath.takeDirectory in \x -> if FilePath.hasTrailingPathSeparator x then p (p x) else p x
-        defaultStdPath = (parent . parent . parent $ exePath) <</>> "config" <</>> "env"
+    let (<</>>)        = (FilePath.</>)  -- purely for convenience,
+                                         -- because </> is defined elswhere
+        parent         = let p = FilePath.takeDirectory
+                         in \x -> if FilePath.hasTrailingPathSeparator x
+                                  then p (p x)
+                                  else p x
+        defaultStdPath = (parent . parent . parent $ exePath)
+                    <</>> "config"
+                    <</>> "env"
         envStdPath     = Map.lookup Project.lunaRootEnv env
         stdPath        = fromMaybe defaultStdPath envStdPath <</>> "Std"
     exists <- doesDirectoryExist stdPath
     if exists
         then putStrLn $ "Found the standard library at: " <> stdPath
-        else die $ "Standard library not found. Set the " <> Project.lunaRootEnv <> " environment variable"
+        else die $ "Standard library not found. Set the "
+                <> Project.lunaRootEnv
+                <> " environment variable"
     return stdPath
 
 main :: IO ()
@@ -139,16 +149,22 @@ main = do
     dependencies <- Project.listDependencies mainPath
     libs         <- Map.fromList <$> Project.projectImportPaths mainPath
     Right (_, imp) <- Project.requestModules libs [[mainName, "Main"]] std
-    let mainFun = imp ^? Project.modules . ix [mainName, "Main"] . importedFunctions . ix "main" . Function.documentedItem
+    let mainFun = imp ^? Project.modules
+                       . ix [mainName, "Main"]
+                       . importedFunctions
+                       . ix "main"
+                       . Function.documentedItem
     case mainFun of
         Just (Left e)  -> do
             putStrLn "Luna encountered the following compilation errors:"
-            Terminal.putStrLn $ Layout.concatLineBlock $ Layout.render $ formatErrors e
+            Terminal.putStrLn $ Layout.concatLineBlock $ Layout.render $
+                formatErrors e
             putStrLn ""
             liftIO $ die "Compilation failed."
         Just (Right f) -> do
             putStrLn "Running main..."
-            res <- liftIO $ runIO $ runError $ LunaValue.force $ f ^. Function.value
+            res <- liftIO $ runIO $ runError $ LunaValue.force $
+                f ^. Function.value
             case res of
                 Left err -> error $ "Luna encountered runtime error: " ++ err
                 _        -> return ()


### PR DESCRIPTION
Probably the biggest change here is that assignQualName always includes the project name in the qualified name, that simplifies handling these names in Luna Studio. Also, LUNA_HOME env variable is unified with Luna Studi and changed to LUNA_LIBS_PATH