### PR TITLE
Report errors for malformed pattern matches

### DIFF
--- a/core/src-libs/Data/Event.hs
+++ b/core/src-libs/Data/Event.hs
@@ -13,7 +13,7 @@ import           Data.Path     as X
 -- WIP:
 import           OCI.IR.Layout.Class (Abstract)
 import           Control.Monad.State.Dependent (StateT)
-
+import           Control.Monad.Except          (ExceptT)
 
 
 data Event
@@ -87,6 +87,7 @@ type family Emitters as m :: Constraint where
     Emitters (a ': as) m = (Emitter a m, Emitters as m)
 
 instance Emitter e m => Emitter e (StateT s m)
+instance Emitter e m => Emitter e (ExceptT s m)
 
 -----------------------
 -- === Listeners === --

--- a/core/src-libs/Data/Graph/Class.hs
+++ b/core/src-libs/Data/Graph/Class.hs
@@ -10,6 +10,7 @@ import           Data.TypeDesc
 -- import           Control.Monad.State       (StateT, evalStateT)
 import qualified Control.Monad.State       as OldState
 import           Control.Monad.State.Dependent
+import qualified Control.Monad.Except      as Except
 import           Control.Monad.Trans.Maybe (MaybeT)
 import qualified Data.Map                  as Map
 import           Data.Map                  (Map)
@@ -325,8 +326,9 @@ instance {-# OVERLAPPABLE #-} (MonadRefStore k m, MonadTrans t, Monad (t m), Get
 -- === RefHandler === --
 
 type family   GetRefHandler (m :: * -> *) :: * -> *
-type instance GetRefHandler (MaybeT m)   = GetRefHandler m
-type instance GetRefHandler (StateT s m) = GetRefHandler m
+type instance GetRefHandler (MaybeT m)            = GetRefHandler m
+type instance GetRefHandler (Except.ExceptT e m)  = GetRefHandler m
+type instance GetRefHandler (StateT s m)          = GetRefHandler m
 type instance GetRefHandler (OldState.StateT s m) = GetRefHandler m
 
 type Ref'     k a m = Ref     k a (GetRefHandler m)

--- a/passes/src/Luna/Pass/Inference/StructuralTyping.hs
+++ b/passes/src/Luna/Pass/Inference/StructuralTyping.hs
@@ -100,7 +100,7 @@ attachStructuralType knownMonad expr = do
                     lam a restM `inMonadM` cons_ @Draft "Pure"
             res@(resM, _) <- lamsInPure asM (oM, oT)
             uni <- unify nM resM
-            reconnectLayer' @Requester (Just expr) (unsafeGeneralize uni :: Expr Draft)
+            reconnectLayer' @Requester (Just expr) (generalize uni :: Expr Draft)
             modifyAttr_ @Unifications $ wrap . (generalize uni :) . unwrap
             return res
         Grouped a  -> getStructuralType knownMonad =<< source a
@@ -120,8 +120,10 @@ attachStructuralType knownMonad expr = do
             apps     <- forM clauses $ \(cM, cT) -> do
                 aT <- app cM iM `inMonadM` var =<< genName
                 modifyAttr_ @SimplifierQueue $ wrap . (fst aT :) . unwrap
+                reconnectLayer' @Requester (Just expr) (fst aT)
                 return aT
             typeUnis <- mapM (unify newtp . snd) apps
+            forM_ typeUnis $ \uni -> reconnectLayer' @Requester (Just expr) (generalize uni :: Expr Draft)
             modifyAttr_ @Unifications $ wrap . (fmap generalize typeUnis ++) . unwrap
             monUni   <- mergeMany =<< mapM (source <=< fmap (view $ wrapped . termMonadic_monad) . readTerm . fst) apps
             return newtp `inMonadM` return monUni

--- a/passes/src/Luna/Pass/Inference/StructuralTyping.hs
+++ b/passes/src/Luna/Pass/Inference/StructuralTyping.hs
@@ -123,7 +123,8 @@ attachStructuralType knownMonad expr = do
                 reconnectLayer' @Requester (Just expr) (fst aT)
                 return aT
             typeUnis <- mapM (unify newtp . snd) apps
-            forM_ typeUnis $ \uni -> reconnectLayer' @Requester (Just expr) (generalize uni :: Expr Draft)
+            forM_ typeUnis $ \(generalize -> uni :: Expr Draft) ->
+                reconnectLayer' @Requester (Just expr) uni
             modifyAttr_ @Unifications $ wrap . (fmap generalize typeUnis ++) . unwrap
             monUni   <- mergeMany =<< mapM (source <=< fmap (view $ wrapped . termMonadic_monad) . readTerm . fst) apps
             return newtp `inMonadM` return monUni

--- a/passes/src/Luna/Pass/Resolution/ConstructorResolution.hs
+++ b/passes/src/Luna/Pass/Resolution/ConstructorResolution.hs
@@ -17,10 +17,8 @@ import           Data.Maybe        (isJust)
 import           OCI.Pass        (Pass, SubPass, Inputs, Outputs, Preserves, Events)
 import qualified OCI.Pass        as Pass
 import           Luna.Pass.Resolution.Data.UnresolvedConses
+import           Luna.Pass.Resolution.Data.ImportError      (ImportError (..), consImportErrorDoc)
 import           Luna.Pass.Data.ExprMapping
-
-data ImportError = SymbolNotFound
-                 | SymbolAmbiguous [Name]
 
 data ConstructorResolution
 type instance Abstract  ConstructorResolution = ConstructorResolution
@@ -49,16 +47,12 @@ lookupCons n imps = case itoListOf (importedClasses .> itraversed <. documentedI
     [(_, c)] -> Right c
     matches  -> Left . SymbolAmbiguous $ fst <$> matches
 
-importErrorDoc :: Name -> ImportError -> Text
-importErrorDoc n SymbolNotFound         = "Can't find constructor: " <> " " <> fromString (show n)
-importErrorDoc n (SymbolAmbiguous mods) = "Constructor" <> " " <> fromString (show n) <> " " <> "is ambiguous." <> "\n" <> "It's exported by the following modules: " <> "\n" <> (foldl (\l r -> l <> "\n" <> r) "" $ fromString . show <$> mods)
-
 resolveCons :: (MonadRef m, MonadPassManager m) => Expr Cons -> SubPass ConstructorResolution m ()
 resolveCons c = do
     Named.Term (Named.Cons n fields) <- readTerm c
     res <- lookupCons n <$> getAttr @Imports
     case res of
-        Left err   -> modifyLayer_ @Errors c (CompileError (importErrorDoc n err) [] [] :)
+        Left err   -> modifyLayer_ @Errors c (CompileError (consImportErrorDoc n err) [] [] :)
         Right cons -> do
             imported <- importConstructor $ cons ^. constructor
             args     <- mapM source fields

--- a/passes/src/Luna/Pass/Resolution/ConstructorResolution.hs
+++ b/passes/src/Luna/Pass/Resolution/ConstructorResolution.hs
@@ -52,7 +52,9 @@ resolveCons c = do
     Named.Term (Named.Cons n fields) <- readTerm c
     res <- lookupCons n <$> getAttr @Imports
     case res of
-        Left err   -> modifyLayer_ @Errors c (CompileError (consImportErrorDoc n err) [] [] :)
+        Left err   -> do
+            let error = CompileError (consImportErrorDoc n err) [] []
+            modifyLayer_ @Errors c (error :)
         Right cons -> do
             imported <- importConstructor $ cons ^. constructor
             args     <- mapM source fields

--- a/passes/src/Luna/Pass/Resolution/Data/ImportError.hs
+++ b/passes/src/Luna/Pass/Resolution/Data/ImportError.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Luna.Pass.Resolution.Data.ImportError where
+
+import Luna.Prelude
+import OCI.IR.Name
+
+data ImportError = SymbolNotFound
+                 | SymbolAmbiguous [Name]
+
+consImportErrorDoc :: Name -> ImportError -> Text
+consImportErrorDoc n SymbolNotFound         =
+    "Can't find constructor: " <> fromString (show n)
+consImportErrorDoc n (SymbolAmbiguous mods) =
+    let moduleList = foldl (\l r -> l <> "\n" <> r) "" $ fromString . show <$> mods
+    in "Constructor " <> fromString (show n) <> " is ambiguous.\n"
+       <> "It's exported by the following modules: \n" <> moduleList
+

--- a/passes/src/Luna/Pass/Resolution/Data/ImportError.hs
+++ b/passes/src/Luna/Pass/Resolution/Data/ImportError.hs
@@ -5,14 +5,17 @@ module Luna.Pass.Resolution.Data.ImportError where
 import Luna.Prelude
 import OCI.IR.Name
 
+type ModuleName = Name
+
 data ImportError = SymbolNotFound
-                 | SymbolAmbiguous [Name]
+                 | SymbolAmbiguous [ModuleName]
 
 consImportErrorDoc :: Name -> ImportError -> Text
 consImportErrorDoc n SymbolNotFound         =
     "Can't find constructor: " <> fromString (show n)
 consImportErrorDoc n (SymbolAmbiguous mods) =
-    let moduleList = foldl (\l r -> l <> "\n" <> r) "" $ fromString . show <$> mods
+    let mkLines    = foldl (\l r -> l <> "\n" <> r) ""
+        moduleList = mkLines $ fromString . show <$> mods
     in "Constructor " <> fromString (show n) <> " is ambiguous.\n"
        <> "It's exported by the following modules: \n" <> moduleList
 

--- a/passes/src/Luna/Pass/Resolution/DeconstructorResolution.hs
+++ b/passes/src/Luna/Pass/Resolution/DeconstructorResolution.hs
@@ -1,6 +1,10 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Luna.Pass.Resolution.DeconstructorResolution where
 
 import Luna.Prelude hiding (String, Destructor)
+import Control.Monad.State.Dependent (MonadGetter, MonadSetter)
+import Control.Monad.Except          (ExceptT, runExceptT, throwError)
 import Luna.Builtin.Data.Function as Function
 import Luna.Builtin.Data.Class    as Class
 import Luna.Builtin.Data.Module   as Module
@@ -15,31 +19,45 @@ import           Data.Maybe        (isJust)
 import           OCI.Pass        (Pass, SubPass, Inputs, Outputs, Preserves, Events)
 import qualified OCI.Pass        as Pass
 import           Luna.Pass.Resolution.Data.UnresolvedConses
+import           Luna.Pass.Resolution.Data.ImportError      (ImportError (..), consImportErrorDoc)
 import           Luna.Pass.Inference.Data.Unifications
-
-data ImportError = SymbolNotFound
-                 | SymbolAmbiguous [Name]
 
 data DeconstructorResolution
 type instance Abstract  DeconstructorResolution = DeconstructorResolution
 
 type instance Inputs     Net   DeconstructorResolution = '[AnyExpr, AnyExprLink]
-type instance Inputs     Layer DeconstructorResolution = '[AnyExpr // Model, AnyExpr // Type, AnyExpr // Succs, AnyExpr // UID, AnyExprLink // Model, AnyExprLink // UID]
+type instance Inputs     Layer DeconstructorResolution = '[AnyExpr // Model, AnyExpr // Type, AnyExpr // Succs, AnyExpr // UID, AnyExpr // Requester, AnyExpr // Errors, AnyExprLink // Model, AnyExprLink // UID]
 type instance Inputs     Attr  DeconstructorResolution = '[NegativeConses, Imports, Unifications]
 type instance Inputs     Event DeconstructorResolution = '[]
 
 type instance Outputs    Net   DeconstructorResolution = '[AnyExpr, AnyExprLink]
-type instance Outputs    Layer DeconstructorResolution = '[AnyExpr // Model, AnyExpr // Type, AnyExpr // Succs, AnyExpr // UID, AnyExprLink // Model, AnyExprLink // UID]
+type instance Outputs    Layer DeconstructorResolution = '[AnyExpr // Model, AnyExpr // Type, AnyExpr // Succs, AnyExpr // UID, AnyExpr // Requester, AnyExpr // Errors, AnyExprLink // Model, AnyExprLink // UID]
 type instance Outputs    Attr  DeconstructorResolution = '[NegativeConses, Unifications]
 type instance Outputs    Event DeconstructorResolution = '[New // AnyExpr, New // AnyExprLink, Event.Import // AnyExpr, Event.Import // AnyExprLink, Delete // AnyExpr, Delete // AnyExprLink, OnDeepDelete // AnyExpr]
 
 type instance Preserves        DeconstructorResolution = '[]
 
+instance MonadGetter s m => MonadGetter s (ExceptT r m)
+instance MonadSetter s m => MonadSetter s (ExceptT r m)
+
 runDeconstructorResolution :: (MonadRef m, MonadPassManager m) => Pass DeconstructorResolution m
 runDeconstructorResolution = do
     conses <- unwrap <$> getAttr @NegativeConses
-    mapM_ resolveDecons conses
+    forM_ conses $ \cons -> do
+        res <- resolveDecons cons
+        case res of
+            Left err -> modifyLayer_ @Errors cons (CompileError err [] [] :)
+            _        -> return ()
     putAttr @NegativeConses $ NegativeConses []
+
+wrongArgumentsCountError :: Int -> Int -> Name -> Text
+wrongArgumentsCountError expected given cons =  "Wrong number of arguments for constructor "
+                                             <> fromString (show cons)
+                                             <> ". Expected "
+                                             <> convert (show expected)
+                                             <> " but got "
+                                             <> convert (show given)
+                                             <> "."
 
 lookupDestr :: Name -> Imports -> Either ImportError Destructor
 lookupDestr n imps = case itoListOf (importedClasses .> itraversed <. Function.documentedItem . Class.constructors . ix n) imps of
@@ -47,18 +65,24 @@ lookupDestr n imps = case itoListOf (importedClasses .> itraversed <. Function.d
     [(_, d)] -> Right $ snd d
     matches  -> Left . SymbolAmbiguous $ fst <$> matches
 
-resolveDecons :: (MonadRef m, MonadPassManager m) => Expr Cons -> SubPass DeconstructorResolution m (Either ImportError ())
+resolveDecons :: (MonadRef m, MonadPassManager m) => Expr Cons
+              -> SubPass DeconstructorResolution m (Either Text ())
 resolveDecons c = do
     Named.Term (Named.Cons n fields) <- readTerm c
     res <- lookupDestr n <$> getAttr @Imports
     case res of
-        Left err   -> return $ Left err
-        -- TODO: throw err when number of arguments does not match
-        Right dest -> do
+        Left err   -> return . Left $ consImportErrorDoc n err
+        Right dest -> runExceptT $ do
             (root, argTypes) <- importDestructor dest
+            let expectedArgsCount = length argTypes
+                givenArgsCount    = length fields
+            when (expectedArgsCount /= givenArgsCount) $
+                throwError (wrongArgumentsCountError expectedArgsCount givenArgsCount n)
             rootTp           <- getLayer @Type c >>= source
             rootUni          <- unify rootTp root
             argTps           <- mapM (source >=> getLayer @Type >=> source) fields
             argUnis          <- zipWithM unify argTps argTypes
-            modifyAttr_ @Unifications $ wrap . ((unsafeRelayout rootUni : fmap unsafeRelayout argUnis) ++) . unwrap
-            return $ Right ()
+            let unis :: [Expr Unify] = unsafeRelayout rootUni : fmap unsafeRelayout argUnis
+            modifyAttr_ @Unifications $ wrap . (unis ++) . unwrap
+            forM_ unis $ reconnectLayer' @Requester (Just c)
+            return ()

--- a/passes/src/Luna/Pass/Resolution/DeconstructorResolution.hs
+++ b/passes/src/Luna/Pass/Resolution/DeconstructorResolution.hs
@@ -19,21 +19,48 @@ import           Data.Maybe        (isJust)
 import           OCI.Pass        (Pass, SubPass, Inputs, Outputs, Preserves, Events)
 import qualified OCI.Pass        as Pass
 import           Luna.Pass.Resolution.Data.UnresolvedConses
-import           Luna.Pass.Resolution.Data.ImportError      (ImportError (..), consImportErrorDoc)
+import           Luna.Pass.Resolution.Data.ImportError ( ImportError (..)
+                                                       , consImportErrorDoc)
 import           Luna.Pass.Inference.Data.Unifications
 
 data DeconstructorResolution
 type instance Abstract  DeconstructorResolution = DeconstructorResolution
 
 type instance Inputs     Net   DeconstructorResolution = '[AnyExpr, AnyExprLink]
-type instance Inputs     Layer DeconstructorResolution = '[AnyExpr // Model, AnyExpr // Type, AnyExpr // Succs, AnyExpr // UID, AnyExpr // Requester, AnyExpr // Errors, AnyExprLink // Model, AnyExprLink // UID]
-type instance Inputs     Attr  DeconstructorResolution = '[NegativeConses, Imports, Unifications]
+type instance Inputs     Layer DeconstructorResolution = '[ AnyExpr // Model
+                                                          , AnyExpr // Type
+                                                          , AnyExpr // Succs
+                                                          , AnyExpr // UID
+                                                          , AnyExpr // Requester
+                                                          , AnyExpr // Errors
+                                                          , AnyExprLink // Model
+                                                          , AnyExprLink // UID
+                                                          ]
+type instance Inputs     Attr  DeconstructorResolution = '[ NegativeConses
+                                                          , Imports
+                                                          , Unifications]
 type instance Inputs     Event DeconstructorResolution = '[]
 
 type instance Outputs    Net   DeconstructorResolution = '[AnyExpr, AnyExprLink]
-type instance Outputs    Layer DeconstructorResolution = '[AnyExpr // Model, AnyExpr // Type, AnyExpr // Succs, AnyExpr // UID, AnyExpr // Requester, AnyExpr // Errors, AnyExprLink // Model, AnyExprLink // UID]
-type instance Outputs    Attr  DeconstructorResolution = '[NegativeConses, Unifications]
-type instance Outputs    Event DeconstructorResolution = '[New // AnyExpr, New // AnyExprLink, Event.Import // AnyExpr, Event.Import // AnyExprLink, Delete // AnyExpr, Delete // AnyExprLink, OnDeepDelete // AnyExpr]
+type instance Outputs    Layer DeconstructorResolution = '[ AnyExpr // Model
+                                                          , AnyExpr // Type
+                                                          , AnyExpr // Succs
+                                                          , AnyExpr // UID
+                                                          , AnyExpr // Requester
+                                                          , AnyExpr // Errors
+                                                          , AnyExprLink // Model
+                                                          , AnyExprLink // UID
+                                                          ]
+type instance Outputs    Attr  DeconstructorResolution = '[ NegativeConses
+                                                          , Unifications
+                                                          ]
+type instance Outputs    Event DeconstructorResolution = '[ New // AnyExpr
+                                                          , New // AnyExprLink
+                                                          , Event.Import // AnyExpr
+                                                          , Event.Import // AnyExprLink
+                                                          , Delete // AnyExpr
+                                                          , Delete // AnyExprLink
+                                                          , OnDeepDelete // AnyExpr]
 
 type instance Preserves        DeconstructorResolution = '[]
 
@@ -44,20 +71,21 @@ runDeconstructorResolution :: (MonadRef m, MonadPassManager m) => Pass Deconstru
 runDeconstructorResolution = do
     conses <- unwrap <$> getAttr @NegativeConses
     forM_ conses $ \cons -> do
-        res <- resolveDecons cons
+        res <- resolveDeconstructor cons
         case res of
             Left err -> modifyLayer_ @Errors cons (CompileError err [] [] :)
             _        -> return ()
     putAttr @NegativeConses $ NegativeConses []
 
 wrongArgumentsCountError :: Int -> Int -> Name -> Text
-wrongArgumentsCountError expected given cons =  "Wrong number of arguments for constructor "
-                                             <> fromString (show cons)
-                                             <> ". Expected "
-                                             <> convert (show expected)
-                                             <> " but got "
-                                             <> convert (show given)
-                                             <> "."
+wrongArgumentsCountError expected given cons
+    =  "Wrong number of arguments for constructor "
+    <> fromString (show cons)
+    <> ". Expected "
+    <> convert (show expected)
+    <> " but got "
+    <> convert (show given)
+    <> "."
 
 lookupDestr :: Name -> Imports -> Either ImportError Destructor
 lookupDestr n imps = case itoListOf (importedClasses .> itraversed <. Function.documentedItem . Class.constructors . ix n) imps of
@@ -65,9 +93,9 @@ lookupDestr n imps = case itoListOf (importedClasses .> itraversed <. Function.d
     [(_, d)] -> Right $ snd d
     matches  -> Left . SymbolAmbiguous $ fst <$> matches
 
-resolveDecons :: (MonadRef m, MonadPassManager m) => Expr Cons
-              -> SubPass DeconstructorResolution m (Either Text ())
-resolveDecons c = do
+resolveDeconstructor :: (MonadRef m, MonadPassManager m) => Expr Cons
+                     -> SubPass DeconstructorResolution m (Either Text ())
+resolveDeconstructor c = do
     Named.Term (Named.Cons n fields) <- readTerm c
     res <- lookupDestr n <$> getAttr @Imports
     case res of
@@ -77,7 +105,9 @@ resolveDecons c = do
             let expectedArgsCount = length argTypes
                 givenArgsCount    = length fields
             when (expectedArgsCount /= givenArgsCount) $
-                throwError (wrongArgumentsCountError expectedArgsCount givenArgsCount n)
+                throwError $ wrongArgumentsCountError expectedArgsCount
+                                                      givenArgsCount
+                                                      n
             rootTp           <- getLayer @Type c >>= source
             rootUni          <- unify rootTp root
             argTps           <- mapM (source >=> getLayer @Type >=> source) fields


### PR DESCRIPTION
This fixes some silent modes of failure for malformed pattern matches, in particular #194 .
The pattern match cases that start throwing errors are caused by:
1. Using an undefined constructor in pattern;
2. Defining branches matching on constructors of different types;
3. Applying the constructor in pattern to too small a number of arguments.

The following functions did not report a compile error when they should (resulting in either runtime crashes or accidentally working) and they do report an error now:
```
def test1:
    case Just 5 of
        Jsut 5: 5

def test2:
    case Just 5 of
        20: 0
        Left foo: foo
        Just x: x

def test3:
    case Just 5 of
        Just: 20
```
