### PR TITLE
Make throwing errors halt graph execution

### DIFF
--- a/core/src/Luna/Builtin/Data/LunaEff.hs
+++ b/core/src/Luna/Builtin/Data/LunaEff.hs
@@ -39,6 +39,9 @@ instance Monad LunaEff where
             LunaPure    r -> return r
             LunaMonadic r -> r
 
+instance MonadIO LunaEff where
+    liftIO = LunaMonadic . liftIO
+
 {-newtype LunaEffCont a = LunaEffCont { runLunaEff :: forall w. (a -> PE w) -> PE w }-}
 
 {-instance Functor LunaEffCont where-}

--- a/passes/src/Luna/Pass/Evaluation/Interpreter.hs
+++ b/passes/src/Luna/Pass/Evaluation/Interpreter.hs
@@ -6,6 +6,7 @@ import Prelude as P (read)
 import Luna.Prelude   as P hiding (seq, force, Constructor, Text)
 import GHC.Exts (Any)
 import Unsafe.Coerce (unsafeCoerce)
+import Data.IORef    (IORef, newIORef, readIORef, writeIORef)
 
 import Data.Text.Lazy (Text)
 import Data.Map (Map)
@@ -18,7 +19,7 @@ import qualified Luna.IR.Layer.Errors as Errors
 import           Luna.IR   hiding (get, put, modify)
 import           OCI.Pass (SubPass, Inputs, Outputs, Preserves, Events)
 import qualified OCI.Pass        as Pass
-import           Control.Monad.Trans.State.Lazy (StateT, runStateT, evalStateT, get, gets, put, modify)
+import qualified Control.Monad.Trans.State.Strict as State
 
 import Luna.Builtin.Data.LunaValue
 import Luna.Builtin.Prim
@@ -61,6 +62,37 @@ mergeScopes m = localVars %~ Map.union m
 globalLookup :: Name -> Imports -> Maybe LunaValue
 globalLookup n imps = imps ^? importedFunctions . ix n . documentedItem . _Right . value
 
+
+
+newtype ScopeT m a = ScopeT { unScopeT :: State.StateT (IORef LocalScope) m a } deriving (Functor, Applicative, Monad, MonadIO, MonadTrans)
+
+class Monad m => MonadScope m where
+    get :: m LocalScope
+    put :: LocalScope -> m ()
+
+instance MonadIO m => MonadScope (ScopeT m) where
+    get   = ScopeT $ State.get >>= liftIO . readIORef
+    put s = ScopeT $ State.get >>= liftIO . flip writeIORef s
+
+modify :: MonadScope m => (LocalScope -> LocalScope) -> m ()
+modify f = fmap f get >>= put
+
+gets :: MonadScope m => (LocalScope -> a) -> m a
+gets f = f <$> get
+
+
+runScopeT :: MonadIO m => ScopeT m a -> LocalScope -> m (a, LocalScope)
+runScopeT m scope = do
+    ref      <- liftIO $ newIORef scope
+    result   <- State.evalStateT (unScopeT m) ref
+    newState <- liftIO $ readIORef ref
+    return (result, newState)
+
+evalScopeT :: MonadIO m => ScopeT m a -> LocalScope -> m a
+evalScopeT m scope = fst <$> runScopeT m scope
+
+
+
 mkInt :: Imports -> Integer -> LunaData
 mkInt = toLunaData
 
@@ -73,11 +105,12 @@ mkString = toLunaData
 mkNothing :: Imports -> LunaData
 mkNothing imps = toLunaData imps ()
 
-interpret :: MonadRef m => Imports -> Expr Draft -> SubPass Interpreter m (StateT LocalScope LunaEff LunaData)
+
+interpret :: MonadRef m => Imports -> Expr Draft -> SubPass Interpreter m (ScopeT LunaEff LunaData)
 interpret = interpret'
 
 interpret' :: (MonadRef m, Readers Layer '[AnyExpr // Model, AnyExpr // Type, AnyExprLink // Model, AnyExpr // Errors] m, Editors Net '[AnyExpr, AnyExprLink] m)
-           => Imports -> Expr Draft -> m (StateT LocalScope LunaEff LunaData)
+           => Imports -> Expr Draft -> m (ScopeT LunaEff LunaData)
 interpret' glob expr = do
     errors <- getLayer @Errors expr
     hasErrors <- not . null <$> getLayer @Errors expr
@@ -101,7 +134,7 @@ interpret' glob expr = do
                 env <- get
                 return $ LunaFunction $ \d -> do
                     newBinds <- inpMatcher $ LunaThunk d
-                    evalStateT bodyVal $ mergeScopes newBinds env
+                    evalScopeT bodyVal $ mergeScopes newBinds env
         App f' a' -> do
             f   <- source f'
             a   <- source a'
@@ -109,8 +142,8 @@ interpret' glob expr = do
             arg <- interpret' glob a
             return $ do
                 env  <- get
-                let fun' = evalStateT fun env
-                    arg' = evalStateT arg env
+                let fun' = evalScopeT fun env
+                    arg' = evalScopeT arg env
                 lift $ force $ applyFun fun' arg'
 
         Acc a' name -> do
@@ -125,17 +158,19 @@ interpret' glob expr = do
             lpat <- irrefutableMatcher l
             return $ do
                 env  <- get
-                let rhs' = evalStateT rhs (localInsert l (LunaThunk rhs') env)
+                let rhs' = evalScopeT rhs (localInsert l (LunaThunk rhs') env)
                 rhsV <- lift $ runError $ force rhs'
                 case rhsV of
-                    Left e  -> modify $ localInsert l $ LunaError e
+                    Left e -> do
+                        modify $ localInsert l $ LunaError e
+                        lift $ throw e
                     Right v -> lift (lpat v) >>= modify . mergeScopes
                 return $ mkNothing glob
         ASGFunction n' as' b' -> do
             n   <- source n'
             as  <- mapM (irrefutableMatcher <=< source) as'
             rhs <- interpret' glob =<< source b'
-            let makeFuns []       e = evalStateT rhs e
+            let makeFuns []       e = evalScopeT rhs e
                 makeFuns (m : ms) e = return $ LunaFunction $ \d -> do
                     newBinds <- m $ LunaThunk d
                     makeFuns ms (mergeScopes newBinds e)
@@ -167,10 +202,10 @@ interpret' glob expr = do
                 Lam pat res -> (,) <$> (matcher =<< source pat) <*> (interpret' glob =<< source res)
             return $ do
                 env <- get
-                let tgt' = evalStateT target env
+                let tgt' = evalScopeT target env
                 tgt <- lift $ force tgt'
                 (scope, cl) <- lift $ runMatch clauses tgt
-                lift $ evalStateT cl (mergeScopes scope env)
+                lift $ evalScopeT cl (mergeScopes scope env)
         Marked _ b -> interpret' glob =<< source b
         s -> error $ "unexpected " ++ show s
 

--- a/passes/src/Luna/Pass/UnitCompilation/DefProcessing.hs
+++ b/passes/src/Luna/Pass/UnitCompilation/DefProcessing.hs
@@ -84,6 +84,6 @@ mkDef modName imports currentTarget defRoot = mdo
             let localDef = case currentTarget of
                   TgtDef _ n -> Map.singleton n val
                   _          -> def
-                val = evalStateT value $ LocalScope def localDef
+                val = evalScopeT value $ LocalScope def localDef
 
             return $ Right $ Function rooted val (Assumptions (unwrap unifies) (unwrap merges) (unwrap apps) (getAccs accs))

--- a/stdlib/StdTest/src/Lang/Errors.luna
+++ b/stdlib/StdTest/src/Lang/Errors.luna
@@ -1,0 +1,25 @@
+import Std.Base
+import Std.Test
+
+class ErrorsTest:
+    def testThrowThrows:
+        def test:
+            foo = throw "foo"
+            None
+        TestSubject test . should throwError
+
+    def testThrowBreaksExecution:
+        t = newMVar
+        t.put 0
+        def prepare:
+            foo = throw "foo"
+            t.take
+            t.put 1
+        runError prepare
+        r = t.take
+        TestSubject r . should (be 0)
+
+    def run:
+        Test.specify "`throw` throws an exception"                 self.testThrowThrows
+        Test.specify "`throw` breaks execution of next IO actions" self.testThrowBreaksExecution
+

--- a/stdlib/StdTest/src/Main.luna
+++ b/stdlib/StdTest/src/Main.luna
@@ -1,6 +1,8 @@
 import Std.Base
 import Std.Test
 import StdTest.Lang.PatternMatch
+import StdTest.Lang.Errors
 
 def main:
     PatternMatchTest.run
+    ErrorsTest.run

--- a/stdlib/src/Luna/Std/Builder.hs
+++ b/stdlib/src/Luna/Std/Builder.hs
@@ -4,7 +4,6 @@ module Luna.Std.Builder where
 
 import           Luna.Prelude                                 hiding (cons)
 import           Luna.IR
-import           Control.Monad.Trans.State                    (evalStateT)
 import           Data.Set                                     (Set)
 import qualified Data.Set                                     as Set
 import           Data.Map                                     (Map)
@@ -25,7 +24,7 @@ import qualified OCI.Pass                                     as Pass
 import           OCI.IR.Combinators                           (reconnectLayer', replace)
 import           Luna.Builtin.Data.LunaValue                  (LunaValue)
 import           Luna.Pass.Typechecking.Typecheck             (typecheck)
-import           Luna.Pass.Evaluation.Interpreter             (interpret)
+import           Luna.Pass.Evaluation.Interpreter             (interpret, evalScopeT)
 
 data LTp = LVar Name | LCons Name [LTp]
 
@@ -116,7 +115,7 @@ compileFunction imps pass = do
             let whiteList = Set.unions [Set.singleton (generalize tp), Set.fromList (generalize <$> unwrap unifies), Set.fromList (generalize <$> unwrap merges), Set.fromList (generalize <$> unwrap apps), Set.fromList (generalize <$> getAccs accs)]
             deepDeleteWithWhitelist root whiteList
             compile tp
-        return $ Function rooted (evalStateT val def) (Assumptions (unwrap unifies) (unwrap merges) (unwrap apps) (getAccs accs))
+        return $ Function rooted (evalScopeT val def) (Assumptions (unwrap unifies) (unwrap merges) (unwrap apps) (getAccs accs))
     return res
 
 preludeUnaryOp :: Name -> IO Function


### PR DESCRIPTION
This fixes the behavior of exceptions in Luna. So far these were sometimes implicitly converted into benign errors, which resulted in strange behaviors with IO actions – they would sometimes silently fail. This is evidenced by the added specs, both of which failed before.

Note the change of `StateT LocalScope` to a mutable reference instead. This is done to be able to get the scope computed so far for display in Luna Studio, without restructuring the monadic stack. It will also prove handy for visualizing results inside functions and providing error stack traces.