### PR TITLE
Language Extension Fixes

### DIFF
--- a/config/hpack-common.yaml
+++ b/config/hpack-common.yaml
@@ -1,0 +1,51 @@
+
+# from https://github.com/sol/hpack#not-repeating-yourself
+
+_default-language-extensions: &luna-extensions
+    - AllowAmbiguousTypes
+    - ApplicativeDo
+    - BangPatterns
+    - BinaryLiterals
+    - ConstraintKinds
+    - DataKinds
+    - DefaultSignatures
+    - DeriveDataTypeable
+    - DeriveFoldable
+    - DeriveFunctor
+    - DeriveGeneric
+    - DeriveTraversable
+    - DoAndIfThenElse
+    - DuplicateRecordFields
+    - EmptyDataDecls
+    - FlexibleContexts
+    - FlexibleInstances
+    - FunctionalDependencies
+    - GeneralizedNewtypeDeriving
+    - InstanceSigs
+    - LambdaCase
+    - LiberalTypeSynonyms
+    - MonadComprehensions
+    - MultiWayIf
+    - NamedWildCards
+    - NegativeLiterals
+    - NoImplicitPrelude
+    - NumDecimals
+    - OverloadedLabels
+    - OverloadedStrings
+    - PackageImports
+    - PatternSynonyms
+    - QuasiQuotes
+    - RankNTypes
+    - RecursiveDo
+    - RelaxedPolyRec
+    - ScopedTypeVariables
+    - StandaloneDeriving
+    - TemplateHaskell
+    - TupleSections
+    - TypeApplications
+    - TypeFamilies
+    - TypeFamilyDependencies
+    - TypeOperators
+    - UnicodeSyntax
+    - ViewPatterns
+

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../config/hpack-common.yaml"
+
 name        : luna-core
 version     : 0.0.6
 synopsis    : Luna Core
@@ -134,52 +136,5 @@ tests:
             - prologue
             - random
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/core/src/Data/Graph/Component/Edge.hs
+++ b/core/src/Data/Graph/Component/Edge.hs
@@ -1,4 +1,7 @@
+{-# LANGUAGE Strict #-}
+
 module Data.Graph.Component.Edge (module X) where
 
 import Data.Graph.Component.Edge.Class        as X
 import Data.Graph.Component.Edge.Construction as X
+

--- a/core/src/Data/Graph/Component/Edge/Class.hs
+++ b/core/src/Data/Graph/Component/Edge/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Data.Graph.Component.Edge.Class where

--- a/core/src/Data/Graph/Component/Edge/Construction.hs
+++ b/core/src/Data/Graph/Component/Edge/Construction.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Data.Graph.Component.Edge.Construction where
 
 import Prologue
@@ -35,3 +37,4 @@ new src tgt = do
     Layer.write @Target link tgt
     pure link
 {-# INLINE new #-}
+

--- a/core/src/Data/Graph/Component/Edge/Destruction.hs
+++ b/core/src/Data/Graph/Component/Edge/Destruction.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Data.Graph.Component.Edge.Destruction where
 
 import Prologue
@@ -24,3 +26,4 @@ delete = \edge -> do
     Mutable.remove srcUsers $! Layout.unsafeRelayout edge
     Component.destruct1 edge
 {-# INLINE delete #-}
+

--- a/core/src/Data/Graph/Component/Node/Class.hs
+++ b/core/src/Data/Graph/Component/Node/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE TypeInType           #-}
 {-# LANGUAGE UndecidableInstances #-}
 

--- a/core/src/Data/Graph/Component/Node/Construction.hs
+++ b/core/src/Data/Graph/Component/Node/Construction.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE TypeInType           #-}
 {-# LANGUAGE UndecidableInstances #-}
 

--- a/core/src/Data/Graph/Component/Node/Destruction.hs
+++ b/core/src/Data/Graph/Component/Node/Destruction.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Data.Graph.Component.Node.Destruction where
 
 import           Prologue hiding (Type)

--- a/core/src/Data/Graph/Component/Node/Layer.hs
+++ b/core/src/Data/Graph/Component/Node/Layer.hs
@@ -1,5 +1,8 @@
+{-# LANGUAGE Strict #-}
+
 module Data.Graph.Component.Node.Layer (module X) where
 
 import Data.Graph.Component.Node.Layer.Model as X
 import Data.Graph.Component.Node.Layer.Type  as X
 import Data.Graph.Component.Node.Layer.Users as X
+

--- a/core/src/Data/Graph/Data.hs
+++ b/core/src/Data/Graph/Data.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Data.Graph.Data (module X) where
 
 import Data.Graph.Data.Component.Class as X

--- a/core/src/Data/Graph/Data/Component/List.hs
+++ b/core/src/Data/Graph/Data/Component/List.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Data.Graph.Data.Component.List where
 
 import Prologue hiding (foldr, mapM)

--- a/core/src/Data/Graph/Data/Component/Maybe.hs
+++ b/core/src/Data/Graph/Data/Component/Maybe.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Data.Graph.Data.Component.Maybe where

--- a/core/src/Data/Graph/Data/Component/Set.hs
+++ b/core/src/Data/Graph/Data/Component/Set.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE TypeInType           #-}
 {-# LANGUAGE UndecidableInstances #-}
 

--- a/core/src/Data/Graph/Data/Component/Vector.hs
+++ b/core/src/Data/Graph/Data/Component/Vector.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE TypeInType           #-}
 {-# LANGUAGE UndecidableInstances #-}
 

--- a/core/src/Data/Graph/Data/Graph/Class.hs
+++ b/core/src/Data/Graph/Data/Graph/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Data.Graph.Data.Graph.Class where

--- a/core/src/Data/Graph/Data/Layer/Class.hs
+++ b/core/src/Data/Graph/Data/Layer/Class.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP                  #-}
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE TypeInType           #-}
 {-# LANGUAGE UndecidableInstances #-}
 

--- a/core/src/Data/Graph/Data/Layer/Layout.hs
+++ b/core/src/Data/Graph/Data/Layer/Layout.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE TypeInType           #-}
 {-# LANGUAGE UndecidableInstances #-}
 

--- a/core/src/Data/Graph/Fold/Class.hs
+++ b/core/src/Data/Graph/Fold/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Data.Graph.Fold.Class where

--- a/core/src/Data/Graph/Fold/Conditional.hs
+++ b/core/src/Data/Graph/Fold/Conditional.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Data.Graph.Fold.Conditional where

--- a/core/src/Data/Graph/Fold/Deep.hs
+++ b/core/src/Data/Graph/Fold/Deep.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Data.Graph.Fold.Deep where

--- a/core/src/Data/Graph/Fold/Filter.hs
+++ b/core/src/Data/Graph/Fold/Filter.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE TypeInType           #-}
 {-# LANGUAGE UndecidableInstances #-}
 

--- a/core/src/Data/Graph/Fold/Layer.hs
+++ b/core/src/Data/Graph/Fold/Layer.hs
@@ -1,4 +1,4 @@
--- {-# LANGUAGE Strict               #-}
+{-# LANGUAGE Strict               #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Data.Graph.Fold.Layer where

--- a/core/src/Data/Graph/Fold/LayerMap.hs
+++ b/core/src/Data/Graph/Fold/LayerMap.hs
@@ -1,4 +1,4 @@
--- {-# LANGUAGE Strict               #-}
+{-# LANGUAGE Strict               #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Data.Graph.Fold.LayerMap where

--- a/core/src/Data/Graph/Fold/Partition.hs
+++ b/core/src/Data/Graph/Fold/Partition.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Data.Graph.Fold.Partition where

--- a/core/src/Data/Graph/Fold/Scoped.hs
+++ b/core/src/Data/Graph/Fold/Scoped.hs
@@ -1,4 +1,4 @@
--- {-# LANGUAGE Strict               #-}
+{-# LANGUAGE Strict               #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Data.Graph.Fold.Scoped where

--- a/core/src/Data/Graph/Fold/ScopedMap.hs
+++ b/core/src/Data/Graph/Fold/ScopedMap.hs
@@ -1,4 +1,4 @@
--- {-# LANGUAGE Strict               #-}
+{-# LANGUAGE Strict               #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Data.Graph.Fold.ScopedMap (module Data.Graph.Fold.ScopedMap, module X) where

--- a/core/src/Data/Graph/Fold/Struct.hs
+++ b/core/src/Data/Graph/Fold/Struct.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Data.Graph.Fold.Struct where

--- a/core/src/Data/Graph/Fold/SubComponents.hs
+++ b/core/src/Data/Graph/Fold/SubComponents.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Data.Graph.Fold.SubComponents where

--- a/core/src/Data/Graph/Fold/SubTree.hs
+++ b/core/src/Data/Graph/Fold/SubTree.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Data.Graph.Fold.SubTree where

--- a/core/src/Data/Graph/Store.hs
+++ b/core/src/Data/Graph/Store.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Data.Graph.Store where
 
 import Prologue hiding (pprint, print, putStrLn)
@@ -212,3 +214,4 @@ deserialize :: ∀ comp layout m. Deserializer m
     => Rooted (Component comp layout)
     -> m (Component comp layout)
 deserialize = fmap fst . deserializeWithRedirects
+

--- a/core/src/Data/Graph/Store/Alloc.hs
+++ b/core/src/Data/Graph/Store/Alloc.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Data.Graph.Store.Alloc where

--- a/core/src/Data/Graph/Store/Buffer.hs
+++ b/core/src/Data/Graph/Store/Buffer.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Data.Graph.Store.Buffer where

--- a/core/src/Data/Graph/Store/Component.hs
+++ b/core/src/Data/Graph/Store/Component.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Data.Graph.Store.Component where

--- a/core/src/Data/Graph/Store/Internal.hs
+++ b/core/src/Data/Graph/Store/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Data.Graph.Store.Internal where

--- a/core/src/Data/Graph/Store/Size/Class.hs
+++ b/core/src/Data/Graph/Store/Size/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Data.Graph.Store.Size.Class where

--- a/core/src/Data/Graph/Store/Size/Discovery.hs
+++ b/core/src/Data/Graph/Store/Size/Discovery.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Data.Graph.Store.Size.Discovery where

--- a/core/src/Data/Graph/Transform/Substitute.hs
+++ b/core/src/Data/Graph/Transform/Substitute.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Data.Graph.Transform.Substitute where
 
 import Prologue

--- a/core/src/Luna.hs
+++ b/core/src/Luna.hs
@@ -1,1 +1,4 @@
+{-# LANGUAGE Strict #-}
+
 module Luna where
+

--- a/core/src/Luna/Data/Name.hs
+++ b/core/src/Luna/Data/Name.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Strict #-}
 
 module Luna.Data.Name (module Luna.Data.Name, module X) where
 import OCI.Data.Name as X
@@ -7,3 +7,4 @@ import Prologue hiding (concat)
 
 mixfix :: NonEmpty Name -> Name
 mixfix = concat . intersperse "." ; {-# INLINE mixfix #-}
+

--- a/core/src/Luna/IR.hs
+++ b/core/src/Luna/IR.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.IR (module X) where
 
 import Data.Graph.Component.Node.Destruction as X

--- a/core/src/Luna/IR/Aliases.hs
+++ b/core/src/Luna/IR/Aliases.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE Strict #-}
 
 module Luna.IR.Aliases where
 

--- a/core/src/Luna/IR/Layer.hs
+++ b/core/src/Luna/IR/Layer.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.IR.Layer (module X) where
 
 import Data.Graph.Data.Layer.Class as X

--- a/core/src/Luna/IR/Link.hs
+++ b/core/src/Luna/IR/Link.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.IR.Link (module X) where
 
 import Data.Graph.Component.Edge as X
+

--- a/core/src/Luna/IR/Term/Ast.hs
+++ b/core/src/Luna/IR/Term/Ast.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.IR.Term.Ast (module X) where
 
 import Luna.IR.Term.Ast.Class as X
+

--- a/core/src/Luna/IR/Term/Ast/Class.hs
+++ b/core/src/Luna/IR/Term/Ast/Class.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP                  #-}
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-unused-foralls #-}
 

--- a/core/src/Luna/IR/Term/Ast/Invalid.hs
+++ b/core/src/Luna/IR/Term/Ast/Invalid.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Luna.IR.Term.Ast.Invalid where
@@ -45,3 +46,4 @@ GTraversable.derive ''InvalidString
 instance NFData Symbol
 instance NFData InvalidLiteral
 instance NFData InvalidString
+

--- a/core/src/Luna/IR/Term/Instances.hs
+++ b/core/src/Luna/IR/Term/Instances.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -18,3 +19,4 @@ import Luna.IR.Term.Core (Top, top)
 --   constructing a new term and we break with it circular dependencies.
 instance Term.Creator Top m => Term.DefaultType m where
     defaultType = coerce <$> top ; {-# INLINE defaultType #-}
+

--- a/core/src/Luna/IR/Term/Literal.hs
+++ b/core/src/Luna/IR/Term/Literal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-unused-foralls #-}
 

--- a/core/src/Luna/Pass.hs
+++ b/core/src/Luna/Pass.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.Pass (module X) where
 
 import Luna.Pass.Basic                 as X
@@ -7,3 +9,4 @@ import OCI.Pass.Definition.Declaration as X (Attrs, Elems, In, Out, Preserves,
 import OCI.Pass.Definition.Dynamic     as X
 import OCI.Pass.Definition.Interface   as X (Interface)
 import OCI.Pass.State.Cache            as X
+

--- a/core/src/Luna/Pass/Attr.hs
+++ b/core/src/Luna/Pass/Attr.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.Pass.Attr (module X) where
 
 import OCI.Pass.State.Attr as X
+

--- a/core/src/Luna/Pass/Basic.hs
+++ b/core/src/Luna/Pass/Basic.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
 
@@ -36,5 +37,4 @@ type family   BasicPassSpec t where
     BasicPassSpec (Pass.In IR.Links)   = '[IR.Source, IR.Target]
     BasicPassSpec (Pass.In Pass.Attrs) = '[]
     BasicPassSpec (Pass.Out a)         = BasicPassSpec (Pass.In a)
-
 

--- a/core/src/Luna/Pass/Scheduler.hs
+++ b/core/src/Luna/Pass/Scheduler.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.Pass.Scheduler (module X) where
 
 import OCI.Pass.Management.Scheduler as X
+

--- a/core/src/OCI/Data/Name.hs
+++ b/core/src/OCI/Data/Name.hs
@@ -1,4 +1,7 @@
+{-# LANGUAGE Strict #-}
+
 module OCI.Data.Name (module X) where
 
 import OCI.Data.Name.Class     as X
 import OCI.Data.Name.Qualified as X
+

--- a/core/src/OCI/Data/Name/Class.hs
+++ b/core/src/OCI/Data/Name/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module OCI.Data.Name.Class where

--- a/core/src/OCI/Data/Name/Instances.hs
+++ b/core/src/OCI/Data/Name/Instances.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module OCI.Data.Name.Instances where

--- a/core/src/OCI/Data/Name/Qualified.hs
+++ b/core/src/OCI/Data/Name/Qualified.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module OCI.Data.Name.Qualified where

--- a/core/src/OCI/IR/Link/Class.hs
+++ b/core/src/OCI/IR/Link/Class.hs
@@ -1,8 +1,13 @@
+{-# LANGUAGE Strict #-}
+
 module OCI.IR.Link.Class (module OCI.IR.Link.Class, module X) where
+
 import Data.Graph.Component.Edge as X (type (*-*), Source, Target, source,
                                        target)
+
 import Data.Graph.Component.Edge (Edge, Edges, SomeEdge)
 
 type Link     = Edge
 type Links    = Edges
 type SomeLink = SomeEdge
+

--- a/core/src/OCI/IR/Term.hs
+++ b/core/src/OCI/IR/Term.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module OCI.IR.Term (module X) where
 
 import Data.Graph.Component.Node.Layer as X (Model, Type, Users, inputs, model)

--- a/core/src/OCI/IR/Term/Class.hs
+++ b/core/src/OCI/IR/Term/Class.hs
@@ -1,4 +1,7 @@
+{-# LANGUAGE Strict #-}
+
 module OCI.IR.Term.Class (module OCI.IR.Term.Class, module X) where
+
 import Data.Graph.Component.Node.Class as X (showTag)
 
 import qualified Data.Graph.Component.Node.Class as Node
@@ -8,3 +11,4 @@ import Data.Graph.Component.Node.Class (Node, Nodes)
 type Term     = Node
 type Terms    = Nodes
 type SomeTerm = Node.Some
+

--- a/core/src/OCI/IR/Term/Definition.hs
+++ b/core/src/OCI/IR/Term/Definition.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE UndecidableInstances #-}
 

--- a/core/src/OCI/IR/Term/Format.hs
+++ b/core/src/OCI/IR/Term/Format.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE TemplateHaskell #-}
+
 module OCI.IR.Term.Format where
 
 import Prologue
@@ -6,3 +8,4 @@ import Prologue
 
 type family Of    elem   ::  Type
 type family Elems format :: [Type]
+

--- a/core/src/OCI/IR/Term/Layout.hs
+++ b/core/src/OCI/IR/Term/Layout.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module OCI.IR.Term.Layout where

--- a/core/src/OCI/Pass/Definition/Class.hs
+++ b/core/src/OCI/Pass/Definition/Class.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances      #-}
 
 module OCI.Pass.Definition.Class where

--- a/core/src/OCI/Pass/Definition/Declaration.hs
+++ b/core/src/OCI/Pass/Definition/Declaration.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances      #-}
 
 module OCI.Pass.Definition.Declaration where

--- a/core/src/OCI/Pass/Definition/Dynamic.hs
+++ b/core/src/OCI/Pass/Definition/Dynamic.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE TypeInType                #-}
 {-# LANGUAGE UndecidableInstances      #-}
 

--- a/core/src/OCI/Pass/Definition/Interface.hs
+++ b/core/src/OCI/Pass/Definition/Interface.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE TypeInType           #-}
 {-# LANGUAGE UndecidableInstances #-}
 

--- a/core/src/OCI/Pass/Management/Scheduler.hs
+++ b/core/src/OCI/Pass/Management/Scheduler.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module OCI.Pass.Management.Scheduler where
 
 import Prologue as Std

--- a/core/src/OCI/Pass/State/Attr.hs
+++ b/core/src/OCI/Pass/State/Attr.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE TypeInType           #-}
 {-# LANGUAGE UndecidableInstances #-}
 

--- a/core/src/OCI/Pass/State/Cache.hs
+++ b/core/src/OCI/Pass/State/Cache.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module OCI.Pass.State.Cache where

--- a/core/src/OCI/Pass/State/Encoder.hs
+++ b/core/src/OCI/Pass/State/Encoder.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module OCI.Pass.State.Encoder where

--- a/debug/src/Luna/Debug/IR/Visualizer.hs
+++ b/debug/src/Luna/Debug/IR/Visualizer.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE NoStrict #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Luna.Debug.IR.Visualizer where
 

--- a/lib/autovector/package.yaml
+++ b/lib/autovector/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-autovector
 version     : 1.0.0
 category    : Data
@@ -22,52 +24,5 @@ library:
         - prologue >= 3.0.0
         - vector
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/autovector/src/Data/AutoVector/Storable/Mutable.hs
+++ b/lib/autovector/src/Data/AutoVector/Storable/Mutable.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Data.AutoVector.Storable.Mutable where
 
 -- import Prologue hiding (length)

--- a/lib/benchmark/package.yaml
+++ b/lib/benchmark/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-benchmark
 version     : 0.0.1
 stability   : experimental
@@ -55,52 +57,5 @@ tests:
             - luna-yaml-utils
             - prologue
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/benchmark/src/Luna/Benchmark.hs
+++ b/lib/benchmark/src/Luna/Benchmark.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoStrict #-}
+
 module Luna.Benchmark where
 
 import Prologue

--- a/lib/benchmark/src/Luna/Benchmark/Config.hs
+++ b/lib/benchmark/src/Luna/Benchmark/Config.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoStrict #-}
+
 module Luna.Benchmark.Config where
 
 import Prologue

--- a/lib/benchmark/src/Luna/Benchmark/Internal.hs
+++ b/lib/benchmark/src/Luna/Benchmark/Internal.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoStrict #-}
+
 module Luna.Benchmark.Internal where
 
 import System.FilePath (FilePath)

--- a/lib/benchmark/src/Luna/Benchmark/Output.hs
+++ b/lib/benchmark/src/Luna/Benchmark/Output.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoStrict #-}
+
 module Luna.Benchmark.Output where
 
 import Prologue

--- a/lib/benchmark/src/Luna/Benchmark/SrcLoc.hs
+++ b/lib/benchmark/src/Luna/Benchmark/SrcLoc.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NoStrict #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Luna.Benchmark.SrcLoc

--- a/lib/benchmark/src/Luna/Benchmark/State.hs
+++ b/lib/benchmark/src/Luna/Benchmark/State.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoStrict #-}
+
 module Luna.Benchmark.State where
 
 import Prologue

--- a/lib/benchmark/src/Luna/Benchmark/Statistics.hs
+++ b/lib/benchmark/src/Luna/Benchmark/Statistics.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoStrict #-}
+
 module Luna.Benchmark.Statistics where
 
 import Prologue

--- a/lib/benchmark/src/Luna/Benchmark/Statistics/Comparison.hs
+++ b/lib/benchmark/src/Luna/Benchmark/Statistics/Comparison.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoStrict #-}
+
 module Luna.Benchmark.Statistics.Comparison where
 
 import Prologue

--- a/lib/benchmark/src/Luna/Benchmark/Statistics/Comparison/Orphans.hs
+++ b/lib/benchmark/src/Luna/Benchmark/Statistics/Comparison/Orphans.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NoStrict #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Luna.Benchmark.Statistics.Comparison.Orphans where

--- a/lib/benchmark/src/Luna/Benchmark/Statistics/Internal.hs
+++ b/lib/benchmark/src/Luna/Benchmark/Statistics/Internal.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoStrict #-}
+
 module Luna.Benchmark.Statistics.Internal where
 
 import Prologue

--- a/lib/ci/package.yaml
+++ b/lib/ci/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name:       luna-ci
 version:    "0.1"
 author:     Luna Team <contact@luna-lang.org>
@@ -14,53 +16,5 @@ dependencies:
     - hspec
     - hspec-jenkins
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
-
+default-extensions: *luna-extensions
 

--- a/lib/code-builder/package.yaml
+++ b/lib/code-builder/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-code-builder
 version     : 1.0.0
 category    : Data
@@ -23,52 +25,5 @@ library:
         - prologue >= 3.0.0
         - text
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/code-builder/src/Data/Text/CodeBuilder/Builder.hs
+++ b/lib/code-builder/src/Data/Text/CodeBuilder/Builder.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GADTs                     #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE OverloadedStrings         #-}
+{-# LANGUAGE Strict #-}
 
 
 module Data.Text.CodeBuilder.Builder where

--- a/lib/cpp-containers/package.yaml
+++ b/lib/cpp-containers/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-cpp-containers
 version     : 1.0.0
 category    : Data
@@ -35,52 +37,5 @@ library:
         - luna-typelevel
         - prologue >= 3.0.0
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/data-construction/package.yaml
+++ b/lib/data-construction/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-data-construction
 version     : 1.0.0
 category    : Data
@@ -20,52 +22,5 @@ library:
         - base
         - luna-generic-traversable
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/data-property/package.yaml
+++ b/lib/data-property/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-data-property
 version     : 1.0.0
 category    : Data
@@ -19,52 +21,5 @@ library:
     dependencies:
         - base
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/data-storable/package.yaml
+++ b/lib/data-storable/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-data-storable
 version     : 1.0.0
 category    : Data
@@ -23,52 +25,5 @@ library:
         - luna-typelevel
         - prologue >= 3.0.0
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/data-tag/package.yaml
+++ b/lib/data-tag/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-data-tag
 version     : 1.0.0
 category    : Data
@@ -22,52 +24,5 @@ library:
         - prologue >= 3.0.0
         - template-haskell
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/data-typemap/package.yaml
+++ b/lib/data-typemap/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-data-typemap
 version     : 1.0.0
 category    : Data
@@ -23,52 +25,5 @@ library:
         - luna-typelevel
         - prologue >= 3.0.0
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/exception/package.yaml
+++ b/lib/exception/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-exception
 version     : 1.0.0
 category    : Data
@@ -24,52 +26,5 @@ library:
         - prologue >= 3.0.0
         - transformers
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/foreign-utils/package.yaml
+++ b/lib/foreign-utils/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-foreign-utils
 version     : 1.0.0
 category    : Data
@@ -26,52 +28,5 @@ library:
         - prologue >= 3.0.0
         - template-haskell
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/foreign-utils/src/Foreign/ForeignPtr/Utils.hs
+++ b/lib/foreign-utils/src/Foreign/ForeignPtr/Utils.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Foreign.ForeignPtr.Utils (module Foreign.ForeignPtr.Utils, module X) where
 
 import Foreign.ForeignPtr as X

--- a/lib/foreign-utils/src/Memory.hs
+++ b/lib/foreign-utils/src/Memory.hs
@@ -1,6 +1,9 @@
+{-# LANGUAGE Strict #-}
+
 module Memory (module Memory, module X) where
 
 import Memory.Allocation  as X
 import Memory.Data.Ptr    as X
 import Memory.Data.Region as X
 import Memory.Management  as X
+

--- a/lib/foreign-utils/src/Memory/Allocation.hs
+++ b/lib/foreign-utils/src/Memory/Allocation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Memory.Allocation where

--- a/lib/foreign-utils/src/Memory/Data/Ptr.hs
+++ b/lib/foreign-utils/src/Memory/Data/Ptr.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE MagicHash            #-}
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Memory.Data.Ptr where

--- a/lib/foreign-utils/src/Memory/Data/Region.hs
+++ b/lib/foreign-utils/src/Memory/Data/Region.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Memory.Data.Region where

--- a/lib/foreign-utils/src/Memory/Management.hs
+++ b/lib/foreign-utils/src/Memory/Management.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE TypeInType #-}
 
 module Memory.Management where

--- a/lib/future/package.yaml
+++ b/lib/future/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-future
 version     : 1.0.0
 category    : Data
@@ -21,52 +23,5 @@ library:
         - base
         - prologue
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/generic-traversable/package.yaml
+++ b/lib/generic-traversable/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-generic-traversable
 version     : 1.0.0
 category    : Data
@@ -23,52 +25,5 @@ library:
         - template-haskell
         - transformers
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/generic-traversable/src/Data/Generics/Traversable.hs
+++ b/lib/generic-traversable/src/Data/Generics/Traversable.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoMonoLocalBinds        #-}
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances    #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 

--- a/lib/generic-traversable2/package.yaml
+++ b/lib/generic-traversable2/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-generic-traversable2
 version     : 1.0.0
 category    : Data
@@ -23,52 +25,5 @@ library:
         - template-haskell
         - transformers
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/generic-traversable2/src/Data/Generics/Traversable2.hs
+++ b/lib/generic-traversable2/src/Data/Generics/Traversable2.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoMonoLocalBinds        #-}
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances    #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 

--- a/lib/hspec-jenkins/package.yaml
+++ b/lib/hspec-jenkins/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : hspec-jenkins
 version     : 0.1.2
 synopsis    : Jenkins-friendly XML formatter for Hspec
@@ -24,52 +26,5 @@ library:
         - hspec >= 2.5
         - prologue
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/memory-manager/package.yaml
+++ b/lib/memory-manager/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-memory-manager
 version     : 1.0.0
 category    : Data
@@ -30,52 +32,5 @@ library:
         - deepseq
         - prologue >= 3.0.0
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/memory-pool/package.yaml
+++ b/lib/memory-pool/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-memory-pool
 version     : 1.0.0
 synopsis    : Luna Local Libraries
@@ -24,52 +26,5 @@ library:
         - luna-memory-manager
         - prologue >= 3.0.0
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/nested-containers/package.yaml
+++ b/lib/nested-containers/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-nested-containers
 version     : 1.0.0
 category    : Data
@@ -23,52 +25,5 @@ library:
         - lens-utils
         - prologue >= 3.0.0
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/parser-utils/package.yaml
+++ b/lib/parser-utils/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name:       luna-parser-utils
 version:    "0.1"
 author:     Luna Team <contact@luna-lang.org>
@@ -16,52 +18,5 @@ library:
         - hspec
         - hspec-megaparsec
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/syntax-definition/package.yaml
+++ b/lib/syntax-definition/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-syntax-definition
 version     : 1.0.0
 category    : Data
@@ -23,52 +25,5 @@ library:
         - lens-utils
         - prologue >= 3.0.0
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/text-processing/package.yaml
+++ b/lib/text-processing/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-text-processing
 version     : 1.0.0
 category    : Data
@@ -24,52 +26,5 @@ library:
         - prologue >= 3.0.0
         - text
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/th-builder/package.yaml
+++ b/lib/th-builder/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-th-builder
 version     : 1.0.0
 category    : Data
@@ -23,52 +25,5 @@ library:
         - split
         - template-haskell
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/th-builder/src/Language/Haskell/TH/Builder.hs
+++ b/lib/th-builder/src/Language/Haskell/TH/Builder.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE OverloadedStrings         #-}
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances      #-}
 
 module Language.Haskell.TH.Builder (module Language.Haskell.TH.Builder, module X) where

--- a/lib/tuple-utils/package.yaml
+++ b/lib/tuple-utils/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-tuple-utils
 version     : 1.0.0
 category    : Data
@@ -23,52 +25,5 @@ library:
         - prologue >= 3.0.0
         - template-haskell
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/type-cache/package.yaml
+++ b/lib/type-cache/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-type-cache
 version     : 1.0.0
 category    : Data
@@ -22,52 +24,5 @@ library:
         - prologue >= 3.0.0
         - template-haskell
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/typelevel/package.yaml
+++ b/lib/typelevel/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name        : luna-typelevel
 version     : 1.0.0
 category    : Data
@@ -23,52 +25,5 @@ library:
         - prologue >= 3.0.0
         - template-haskell
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/lib/typelevel/src/Type/Data/Map/Generic.hs
+++ b/lib/typelevel/src/Type/Data/Map/Generic.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NoStrict #-}
 {-# LANGUAGE TypeInType           #-}
 {-# LANGUAGE UndecidableInstances #-}
 

--- a/lib/yaml-utils/package.yaml
+++ b/lib/yaml-utils/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../config/hpack-common.yaml"
+
 name:       luna-yaml-utils
 version:    "0.1"
 author:     Luna Team <contact@luna-lang.org>
@@ -16,52 +18,5 @@ library:
         - hspec
         - hspec-megaparsec
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/package/package.yaml
+++ b/package/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../config/hpack-common.yaml"
+
 name:       luna-package
 version:    "0.2"
 author:     Luna Team <contact@luna-lang.org>
@@ -51,52 +53,5 @@ dependencies:
     - text
     - yaml
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/package/src/Luna/Package.hs
+++ b/package/src/Luna/Package.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.Package where
 
 import Prologue

--- a/package/src/Luna/Package/Configuration/Global.hs
+++ b/package/src/Luna/Package/Configuration/Global.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.Package.Configuration.Global where
 
 import Prologue

--- a/package/src/Luna/Package/Configuration/License.hs
+++ b/package/src/Luna/Package/Configuration/License.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.Package.Configuration.License where
 
 import Prologue

--- a/package/src/Luna/Package/Configuration/License/Data.hs
+++ b/package/src/Luna/Package/Configuration/License/Data.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.Package.Configuration.License.Data where
 
 import Prologue

--- a/package/src/Luna/Package/Configuration/Local.hs
+++ b/package/src/Luna/Package/Configuration/Local.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.Package.Configuration.Local where
 
 import Prologue

--- a/package/src/Luna/Package/Structure/Generate.hs
+++ b/package/src/Luna/Package/Structure/Generate.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.Package.Structure.Generate
     ( module Luna.Package.Structure.Generate
     , module X ) where

--- a/package/src/Luna/Package/Structure/Generate/Internal.hs
+++ b/package/src/Luna/Package/Structure/Generate/Internal.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.Package.Structure.Generate.Internal where
 
 import Prologue

--- a/package/src/Luna/Package/Structure/Name.hs
+++ b/package/src/Luna/Package/Structure/Name.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.Package.Structure.Name where
 
 import Prologue

--- a/package/src/Luna/Package/Structure/Utilities.hs
+++ b/package/src/Luna/Package/Structure/Utilities.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.Package.Structure.Utilities where
 
 import Prologue
@@ -37,5 +39,4 @@ findParentPackageIfInside path = do
     else if not $ FilePath.isDrive parentPath then
         findParentPackageIfInside parentPath
     else pure Nothing
-
 

--- a/package/src/Luna/Package/Version.hs
+++ b/package/src/Luna/Package/Version.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.Package.Version where
 
 import Prologue hiding (min, fromString)

--- a/passes/package.yaml
+++ b/passes/package.yaml
@@ -69,8 +69,8 @@ default-extensions:
     - NegativeLiterals
     - NoImplicitPrelude
     - NumDecimals
-    - OverloadedLabels
     - OverloadedStrings
+    - OverloadedLabels
     - PackageImports
     - PatternSynonyms
     - QuasiQuotes
@@ -79,7 +79,6 @@ default-extensions:
     - RelaxedPolyRec
     - ScopedTypeVariables
     - StandaloneDeriving
-    - Strict
     - TemplateHaskell
     - TupleSections
     - TypeApplications

--- a/passes/package.yaml
+++ b/passes/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../config/hpack-common.yaml"
+
 name:       luna-passes
 version:    "0.1"
 author:     Luna Team <contact@luna-lang.org>
@@ -40,52 +42,5 @@ library:
         - transformers
         - uuid-types
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/passes/package.yaml
+++ b/passes/package.yaml
@@ -69,8 +69,8 @@ default-extensions:
     - NegativeLiterals
     - NoImplicitPrelude
     - NumDecimals
-    - OverloadedStrings
     - OverloadedLabels
+    - OverloadedStrings
     - PackageImports
     - PatternSynonyms
     - QuasiQuotes
@@ -79,6 +79,7 @@ default-extensions:
     - RelaxedPolyRec
     - ScopedTypeVariables
     - StandaloneDeriving
+    - Strict
     - TemplateHaskell
     - TupleSections
     - TypeApplications

--- a/passes/src/Luna/Pass/Data/Error.hs
+++ b/passes/src/Luna/Pass/Data/Error.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 

--- a/playground/package.yaml
+++ b/playground/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../config/hpack-common.yaml"
+
 name:       luna-playground
 version:    "0.1"
 author:     Luna Team <contact@luna-lang.org>
@@ -45,52 +47,5 @@ executables:
       - luna-debug
       - luna-memory-manager
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/runtime/package.yaml
+++ b/runtime/package.yaml
@@ -58,7 +58,6 @@ default-extensions:
     - RelaxedPolyRec
     - ScopedTypeVariables
     - StandaloneDeriving
-
     - TemplateHaskell
     - TupleSections
     - TypeApplications

--- a/runtime/package.yaml
+++ b/runtime/package.yaml
@@ -56,7 +56,6 @@ default-extensions:
     - RelaxedPolyRec
     - ScopedTypeVariables
     - StandaloneDeriving
-    - Strict
     - TemplateHaskell
     - TupleSections
     - TypeApplications

--- a/runtime/package.yaml
+++ b/runtime/package.yaml
@@ -17,6 +17,8 @@ dependencies:
     - mtl
     - prologue
 
+
+
 default-extensions:
     - AllowAmbiguousTypes
     - ApplicativeDo
@@ -56,6 +58,7 @@ default-extensions:
     - RelaxedPolyRec
     - ScopedTypeVariables
     - StandaloneDeriving
+
     - TemplateHaskell
     - TupleSections
     - TypeApplications

--- a/runtime/package.yaml
+++ b/runtime/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../config/hpack-common.yaml"
+
 name:       luna-runtime
 version:    "0.1"
 author:     Luna Team <contact@luna-lang.org>
@@ -17,53 +19,5 @@ dependencies:
     - mtl
     - prologue
 
-
-
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/runtime/src/Luna/Runtime.hs
+++ b/runtime/src/Luna/Runtime.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE NoStrict #-}
+-- {-# LANGUAGE NoStrict #-}
+
+{-# OPTIONS_GHC -XNoStrict #-}
 
 module Luna.Runtime (module X) where
 

--- a/runtime/src/Luna/Runtime/Data.hs
+++ b/runtime/src/Luna/Runtime/Data.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NoStrict #-}
-{-# LANGUAGE UndecidableInstances #-}
+-- {-# LANGUAGE NoStrict #-}
+
+{-# OPTIONS_GHC -XNoStrict #-}
 
 module Luna.Runtime.Data where
 

--- a/runtime/src/Luna/Runtime/Data/Evaluated.hs
+++ b/runtime/src/Luna/Runtime/Data/Evaluated.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE NoStrict #-}
+-- {-# LANGUAGE NoStrict #-}
+
+{-# OPTIONS_GHC -XNoStrict #-}
 
 module Luna.Runtime.Data.Evaluated where
 

--- a/runtime/src/Luna/Runtime/Eff.hs
+++ b/runtime/src/Luna/Runtime/Eff.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoStrict #-}
+
 module Luna.Runtime.Eff where
 
 import Prologue hiding (Exception)

--- a/runtime/src/Luna/Runtime/Eff.hs
+++ b/runtime/src/Luna/Runtime/Eff.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NoStrict #-}
+ {-# LANGUAGE Strict #-}
 
 module Luna.Runtime.Eff where
 

--- a/shell/package.yaml
+++ b/shell/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../config/hpack-common.yaml"
+
 name:       luna-shell
 version:    "1.2"
 author:     Luna Team <contact@luna-lang.org>
@@ -62,52 +64,5 @@ benchmarks:
             - prologue
             - template-haskell
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/shell/src-app/Main.hs
+++ b/shell/src-app/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Main where
 
 import Prologue

--- a/shell/src/Luna/Shell/CWD.hs
+++ b/shell/src/Luna/Shell/CWD.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.Shell.CWD where
 
 import Prologue

--- a/shell/src/Luna/Shell/Command.hs
+++ b/shell/src/Luna/Shell/Command.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.Shell.Command where
 
 import Prologue hiding (init)

--- a/shell/src/Luna/Shell/Interpret.hs
+++ b/shell/src/Luna/Shell/Interpret.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.Shell.Interpret where
 
 import Prologue

--- a/shell/src/Luna/Shell/Option.hs
+++ b/shell/src/Luna/Shell/Option.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.Shell.Option (module Luna.Shell.Option, module X) where
 
 import Options.Applicative as X ( execParser, info, fullDesc, progDesc, header

--- a/shell/test/bench-test/tail-recursion/Main.luna
+++ b/shell/test/bench-test/tail-recursion/Main.luna
@@ -3,9 +3,11 @@ import Std.Base
 import Std.Primitive
 
 def recurse a:
-    if a < 1 then 0 else foo (a - 1)
+    if a < 1 then 0 else recurse (a - 1)
 
 def main:
-    count = 1000
+    count = 1
     recurse count
+    print "Exit!"
+    None
 

--- a/shell/test/bench-test/tail-recursion/Main.luna
+++ b/shell/test/bench-test/tail-recursion/Main.luna
@@ -6,7 +6,7 @@ def recurse a:
     if a < 1 then 0 else recurse (a - 1)
 
 def main:
-    count = 1
+    count = 1000000
     recurse count
     print "Exit!"
     None

--- a/stdlib/StdTest/src/Data/List.luna
+++ b/stdlib/StdTest/src/Data/List.luna
@@ -1,0 +1,25 @@
+
+import Std.Base
+import Std.Test
+
+def infiniteDef: Prepend 2 infiniteDef
+
+class ListTest:
+
+    def takeFromInfiniteDef:
+        value    = infiniteDef.take 5
+        expected = [2, 2, 2, 2, 2]
+
+        TestSubject value . should (be expected)
+
+    def takeFromInfiniteVar:
+        a        = Prepend 1 a
+        value    = a.take 4
+        expected = [1, 1, 1, 1]
+
+        TestSubject value . should (be expected)
+
+    def run:
+        Test.specify "can take from an infinite list" self.takeFromInfiniteVar
+        Test.specify "can take from infinite def" self.takeFromInfiniteDef
+

--- a/stdlib/StdTest/src/Lang/Recursion.luna
+++ b/stdlib/StdTest/src/Lang/Recursion.luna
@@ -1,0 +1,16 @@
+
+import Std.Base
+import Std.Test
+
+def recurse a:
+    if a < 1 then 0 else recurse (a - 1)
+
+class RecursionTest:
+
+    def tailRecursion:
+        output = recurse 1000
+        be 0 output
+
+    def run:
+        Test.specify "recursion executes correctly" self.tailRecursion
+

--- a/stdlib/StdTest/src/Lang/SideEffects.luna
+++ b/stdlib/StdTest/src/Lang/SideEffects.luna
@@ -1,0 +1,31 @@
+
+import Std.Base
+import Std.Test
+
+class SideEffectsTest:
+
+    def incrementMVar mv:
+        a = 20
+        mv.put 30
+        b = 30
+        a + b
+
+    def testIncrementMVar:
+        v = newMVar
+        self.incrementMVar v
+        result = v.take
+        TestSubject result . should (be 30)
+
+    def testMVarLocal:
+        v = newMVar
+        def test:
+            v.put 40
+        test
+
+        result = v.take
+        TestSubject result . should (be 40)
+
+    def run:
+        Test.specify "Side-effects work in an MVar" self.testIncrementMVar
+        Test.specify "Side-effects work with local def" self.testMVarLocal
+

--- a/stdlib/StdTest/src/Main.luna
+++ b/stdlib/StdTest/src/Main.luna
@@ -1,18 +1,24 @@
 import Std.Base
 import Std.Test
-import StdTest.Lang.PatternMatch
 import StdTest.Lang.Errors
 import StdTest.Lang.FieldModifications
+import StdTest.Lang.PatternMatch
+import StdTest.Lang.Recursion
+import StdTest.Lang.SideEffects
 
+import StdTest.Data.List
 import StdTest.Data.Map
 
 import StdTest.Lib.Basic
 
 def main:
-    PatternMatchTest.run
     ErrorsTest.run
     FieldModificationsTest.run
+    PatternMatchTest.run
+    RecursionTest.run
+    SideEffectsTest.run
 
+    ListTest.run
     MapTest.run
 
     BasicTest.run

--- a/stdlib/package.yaml
+++ b/stdlib/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../config/hpack-common.yaml"
+
 name:       luna-stdlib
 version:    "0.1"
 author:     Luna Team <contact@luna-lang.org>
@@ -58,52 +60,5 @@ dependencies:
     - websockets
     - wuss
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/stdlib/src/Luna/Prim/Base.hs
+++ b/stdlib/src/Luna/Prim/Base.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Strict #-}
 
 module Luna.Prim.Base where
 

--- a/stdlib/src/Luna/Prim/CTypes.hs
+++ b/stdlib/src/Luna/Prim/CTypes.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.Prim.CTypes where
 
 import Prologue

--- a/stdlib/src/Luna/Prim/DynamicLinker.hs
+++ b/stdlib/src/Luna/Prim/DynamicLinker.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Strict            #-}
 
 module Luna.Prim.DynamicLinker (
       loadLibrary

--- a/stdlib/src/Luna/Prim/DynamicLinker/Cache.hs
+++ b/stdlib/src/Luna/Prim/DynamicLinker/Cache.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE CPP               #-}
+{-# LANGUAGE CPP    #-}
+{-# LANGUAGE Strict #-}
 
 module Luna.Prim.DynamicLinker.Cache where
 
@@ -16,7 +17,7 @@ import Luna.Prim.DynamicLinker (Handle, loadLibrary, closeLibrary, loadSymbol)
 #if ! mingw32_HOST_OS
 import qualified System.Posix.DynamicLinker as Unix
 #endif
-    
+
 newtype HandleKey = HandleKey (Ptr ())
     deriving (Eq, Generic, Ord, Show)
 makeLenses ''HandleKey
@@ -29,7 +30,7 @@ toKey = HandleKey
 #else
 toKey :: Handle -> HandleKey
 toKey = HandleKey . Unix.packDL
-#endif    
+#endif
 
 data Cache = Cache
     { _moduleMap :: HashMap Text Handle
@@ -57,8 +58,8 @@ loadLibraryCached (CacheCtx cacheCtx) moduleName = do
             -- Note: loadLibrary can be really slow,
             -- we don't want to run it within MVar
             newHandle <- loadLibrary $ convert moduleName
-            -- In the meantime module could have been added to cache by 
-            -- other thread. We do not want to leak handles - get rid of 
+            -- In the meantime module could have been added to cache by
+            -- other thread. We do not want to leak handles - get rid of
             -- our (now duplicate) one.
             modifyMVar cacheCtx $ \cache ->
                 case lookupModule cache of
@@ -68,7 +69,7 @@ loadLibraryCached (CacheCtx cacheCtx) moduleName = do
                     Nothing -> do
                         let updateMap = HashMap.insert moduleName newHandle
                         pure (over moduleMap updateMap cache, newHandle)
-    
+
 
 lookupSymbolCached :: CacheCtx -> (Handle, Text) -> IO (FunPtr a)
 lookupSymbolCached (CacheCtx cacheCtx) (handle, symbol) = do

--- a/stdlib/src/Luna/Prim/Foreign.hs
+++ b/stdlib/src/Luna/Prim/Foreign.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE MagicHash         #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Strict #-}
 
 module Luna.Prim.Foreign where
 

--- a/stdlib/src/Luna/Prim/HTTP.hs
+++ b/stdlib/src/Luna/Prim/HTTP.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Strict #-}
 
 module Luna.Prim.HTTP where
 

--- a/stdlib/src/Luna/Prim/System.hs
+++ b/stdlib/src/Luna/Prim/System.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE Strict #-}
 
 module Luna.Prim.System where
 

--- a/stdlib/src/Luna/Prim/Time.hs
+++ b/stdlib/src/Luna/Prim/Time.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Strict #-}
 
 module Luna.Prim.Time where
 

--- a/stdlib/src/Luna/Prim/WebSockets.hs
+++ b/stdlib/src/Luna/Prim/WebSockets.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Strict #-}
 
 module Luna.Prim.WebSockets where
 

--- a/stdlib/src/Luna/Std.hs
+++ b/stdlib/src/Luna/Std.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE OverloadedLists   #-}
+{-# LANGUAGE Strict #-}
 
 module Luna.Std where
 

--- a/stdlib/src/Luna/Std/Finalizers.hs
+++ b/stdlib/src/Luna/Std/Finalizers.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.Std.Finalizers where
 
 import Prologue

--- a/stdlib/src/Luna/Std/Instances.hs
+++ b/stdlib/src/Luna/Std/Instances.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Strict #-}
 
 module Luna.Std.Instances where
 

--- a/syntax/text/lexer/package.yaml
+++ b/syntax/text/lexer/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../../config/hpack-common.yaml"
+
 name       : luna-syntax-text-lexer
 version    : "0.2"
 author     : Luna Team <contact@luna-lang.org>
@@ -56,52 +58,5 @@ dependencies:
     - transformers
     - typelevel
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/syntax/text/lexer/src-libs/attoparsec-text32/Data/Attoparsec/Text32.hs
+++ b/syntax/text/lexer/src-libs/attoparsec-text32/Data/Attoparsec/Text32.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NoStrict #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Data.Attoparsec.Text32 where

--- a/syntax/text/lexer/src-libs/conduit-utils/Data/Conduit/Utils.hs
+++ b/syntax/text/lexer/src-libs/conduit-utils/Data/Conduit/Utils.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoStrict #-}
+
 module Data.Conduit.Utils where
 
 import Prelude

--- a/syntax/text/lexer/src-libs/parsing/Data/Parser.hs
+++ b/syntax/text/lexer/src-libs/parsing/Data/Parser.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NoStrict #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Monadic / applicative parser abstractions.

--- a/syntax/text/lexer/src-libs/parsing/Data/Parser/Instances/Attoparsec.hs
+++ b/syntax/text/lexer/src-libs/parsing/Data/Parser/Instances/Attoparsec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NoStrict #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Data.Parser.Instances.Attoparsec where

--- a/syntax/text/lexer/src/Luna/Syntax/Text/Analysis/Disabled.hs
+++ b/syntax/text/lexer/src/Luna/Syntax/Text/Analysis/Disabled.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoStrict #-}
+
 module Luna.Syntax.Text.Analysis.Disabled where
 
 import Prologue                      hiding (span)

--- a/syntax/text/lexer/src/Luna/Syntax/Text/Lexer/Token.hs
+++ b/syntax/text/lexer/src/Luna/Syntax/Text/Lexer/Token.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Luna.Syntax.Text.Lexer.Token where
 
 import Prologue hiding (Symbol, element, span)

--- a/syntax/text/model/package.yaml
+++ b/syntax/text/model/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../../config/hpack-common.yaml"
+
 name       : luna-syntax-text-model
 version    : "0.1"
 author     : Luna Team <contact@luna-lang.org>
@@ -19,52 +21,5 @@ dependencies:
     - prologue
     - vector-text
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/syntax/text/parser/package.yaml
+++ b/syntax/text/parser/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../../config/hpack-common.yaml"
+
 name       : luna-syntax-text-parser
 version    : "0.2"
 author     : Luna Team <contact@luna-lang.org>
@@ -51,52 +53,5 @@ dependencies:
     - vector
     - vector-text
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 

--- a/syntax/text/prettyprint/package.yaml
+++ b/syntax/text/prettyprint/package.yaml
@@ -1,3 +1,5 @@
+_config/lib: !include "../../../config/hpack-common.yaml"
+
 name       : luna-syntax-text-prettyprint
 version    : "0.1"
 author     : Luna Team <contact@luna-lang.org>
@@ -21,52 +23,5 @@ dependencies:
     - prologue
     - text
 
-default-extensions:
-    - AllowAmbiguousTypes
-    - ApplicativeDo
-    - BangPatterns
-    - BinaryLiterals
-    - ConstraintKinds
-    - DataKinds
-    - DefaultSignatures
-    - DeriveDataTypeable
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveTraversable
-    - DoAndIfThenElse
-    - DuplicateRecordFields
-    - EmptyDataDecls
-    - FlexibleContexts
-    - FlexibleInstances
-    - FunctionalDependencies
-    - GeneralizedNewtypeDeriving
-    - InstanceSigs
-    - LambdaCase
-    - LiberalTypeSynonyms
-    - MonadComprehensions
-    - MultiWayIf
-    - NamedWildCards
-    - NegativeLiterals
-    - NoImplicitPrelude
-    - NumDecimals
-    - OverloadedLabels
-    - OverloadedStrings
-    - PackageImports
-    - PatternSynonyms
-    - QuasiQuotes
-    - RankNTypes
-    - RecursiveDo
-    - RelaxedPolyRec
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - Strict
-    - TemplateHaskell
-    - TupleSections
-    - TypeApplications
-    - TypeFamilies
-    - TypeFamilyDependencies
-    - TypeOperators
-    - UnicodeSyntax
-    - ViewPatterns
+default-extensions: *luna-extensions
 


### PR DESCRIPTION
### Pull Request Description
Apparently `default-extensions` supersede those specified in the file headers, which led to an infinite recursion. This PR fixes extensions to be defined globally via an include and then adds strictness pragmas locally in each file.

### Important Notes

- Uses the hpack `!include` directive to centralise the `default-extensions` into one place. 

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md).
- [x] The code has been tested where possible.

