### PR TITLE
Fix compilation issue on windows

### DIFF
--- a/package/src/Luna/Package.hs
+++ b/package/src/Luna/Package.hs
@@ -275,7 +275,9 @@ rename src target = Exception.rethrowFromIO @Path.PathException $ do
     unless_ isValidPkgName . Exception.throw . InvalidName $ convert newName
 
     -- Guaranteed to be in a package by now so default value is nonsensical
-    srcPackageRoot <- fromJust $(Path.mkAbsDir "/") <$> findPackageRoot src
+    defaultDir     <- Directory.getCurrentDirectory
+    defaultDirPath <- Path.parseAbsDir defaultDir
+    srcPackageRoot <- fromJust defaultDirPath <$> findPackageRoot src
     originalName   <- name srcPackageRoot
 
     liftIO $ Directory.renameDirectory (Path.fromAbsDir srcPackageRoot) destPath


### PR DESCRIPTION
### Pull Request Description
An unused default value in `Package.hs` meant that a TH splice wouldn't compile on windows. This PR instead uses the current directory as a default.

Fixes #276.

### Checklist

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md).
- [x] The code has been tested where possible.

