### PR TITLE
Standard library parts of LQuery support for Arrow's Timestamp datatype.

### DIFF
--- a/stdlib/Std/src/Base.luna
+++ b/stdlib/Std/src/Base.luna
@@ -1413,19 +1413,21 @@ def bracket before after thing:
         Right value: value
 
 class LQueryValue:
-    ColumnRef Text
-    ValText   Text
-    ValInt    Int
-    ValReal   Real
+    ColumnRef      Text
+    ValText        Text
+    ValInt         Int
+    ValReal        Real
+    ValTimestampNs Int
     Operation Text (List LQueryValue)
     Condition Predicate LQueryValue LQueryValue
     
     def toJSON: case self of
-        ColumnRef n: JSON.empty . insert "column" n
-        ValText   t: t.toJSON
-        ValInt    i: i.toJSON
-        ValReal   r: r.toJSON
-        Operation n args: JSON.empty.insert "operation" n . insert "arguments" args
+        ColumnRef        n: JSON.empty . insert "column" n
+        ValText          t: t.toJSON
+        ValInt           i: i.toJSON
+        ValReal          r: r.toJSON
+        ValTimestampNs   t: JSON.empty.insert "timestampNs" t
+        Operation   n args: JSON.empty.insert "operation" n . insert "arguments" args
         Condition pred a b: JSON.empty.insert "condition" pred . insert "onTrue" a . insert "onFalse" b
 
     def startsWith t:  Predicate "startsWith" [self, t.toLQueryValue]
@@ -1441,6 +1443,10 @@ class LQueryValue:
     def / that: Operation "divide" [self, that.toLQueryValue]
     def % that: Operation "mod"    [self, that.toLQueryValue]
     def negate: Operation "negate" [self]
+
+    def day:   Operation "day"   [self]
+    def month: Operation "month" [self]
+    def year:  Operation "year"  [self]
 
     def toLQueryValue: self
 

--- a/stdlib/Std/src/Base.luna
+++ b/stdlib/Std/src/Base.luna
@@ -205,7 +205,7 @@ native class Text:
         Nothing:  errorStr ("Could not convert " + self + " to a Real")
 
     def addPathSegment segment: self + pathSeparator + segment
-    
+
     def toLQueryValue: ValText self
 
 # Class for representing arbitrary binary data. Does not attempt to interpret the data in any way.
@@ -1081,7 +1081,7 @@ class JSON:
             (JSONNull    , JSONNull        ): True
             (JSONObject m, JSONObject thatM): m.== thatM
             _: False
-    
+
     # Inserts a value for a given key into the `JSON` object.
     # Throws an exception when the `JSON` does not represent an object.
     def insert k v: case self of
@@ -1413,14 +1413,27 @@ def bracket before after thing:
         Right value: value
 
 class LQueryValue:
+    # Reference a column by its name.
     ColumnRef      Text
+    # Text literal.
     ValText        Text
+    # Integer litaral.
     ValInt         Int
+    # Real literal.
     ValReal        Real
+    # Timestamp literal (nanosecond ticks since the beginning of Unix epoch).
     ValTimestampNs Int
+    # Operation: name of an LQuery function to call and the list of arguments.
     Operation Text (List LQueryValue)
+    # Construction representing if-then-else: depending on predicate either
+    # first or second value shall be returned as the value.
     Condition Predicate LQueryValue LQueryValue
-    
+
+    # Serializes an LQuery value to its JSON representation.
+    # Note: the JSON representation is meant to allow passing LQuery values to
+    # third-party components (like Dataframes library).
+    # Changing serialization scheme here will require adjusting that components
+    # as well.
     def toJSON: case self of
         ColumnRef        n: JSON.empty . insert "column" n
         ValText          t: t.toJSON
@@ -1430,7 +1443,13 @@ class LQueryValue:
         Operation   n args: JSON.empty.insert "operation" n . insert "arguments" args
         Condition pred a b: JSON.empty.insert "condition" pred . insert "onTrue" a . insert "onFalse" b
 
+    # Tests if argument is prefix of this value.
+    # Allowed only for Text-yielding values.
     def startsWith t:  Predicate "startsWith" [self, t.toLQueryValue]
+
+    # Tests if argument being a regexp string matches the current value.
+    # Supported syntax is based on ECMAScript and UNIX regexp grammar.
+    # Allowed only for Text-yielding values.
     def matches regex: Predicate "matches"    [self, regex.toLQueryValue]
 
     def >  that: Predicate "gt" [self, that.toLQueryValue]
@@ -1444,8 +1463,14 @@ class LQueryValue:
     def % that: Operation "mod"    [self, that.toLQueryValue]
     def negate: Operation "negate" [self]
 
+    # Extract day of month (counted from 1) in the Gregorian calendar.
+    # Allowed only for Timestamp-yielding values;
     def day:   Operation "day"   [self]
+    # Extract month in the Gregorian calendar.
+    # Allowed only for Timestamp-yielding values;
     def month: Operation "month" [self]
+    # Extract year in the Gregorian calendar.
+    # Allowed only for Timestamp-yielding values;
     def year:  Operation "year"  [self]
 
     def toLQueryValue: self
@@ -1461,11 +1486,11 @@ class Predicate a:
     def or  that: Boolean "or"  [self, that]
     def not:      Boolean "not" [self]
     def switch a b: Condition self a.toLQueryValue b.toLQueryValue
-    
+
     def toJSON: case self of
         Predicate t args: JSON.empty.insert "predicate" t . insert "arguments" args
         Boolean t args: JSON.empty.insert "boolean" t . insert "arguments" args
 
 class TableHandle:
-    def at name: 
+    def at name:
         ColumnRef name

--- a/stdlib/Std/src/Base.luna
+++ b/stdlib/Std/src/Base.luna
@@ -1413,20 +1413,12 @@ def bracket before after thing:
         Right value: value
 
 class LQueryValue:
-    # Reference a column by its name.
-    ColumnRef      Text
-    # Text literal.
+    ColumnRef      Texts
     ValText        Text
-    # Integer litaral.
     ValInt         Int
-    # Real literal.
     ValReal        Real
-    # Timestamp literal (nanosecond ticks since the beginning of Unix epoch).
     ValTimestampNs Int
-    # Operation: name of an LQuery function to call and the list of arguments.
     Operation Text (List LQueryValue)
-    # Construction representing if-then-else: depending on predicate either
-    # first or second value shall be returned as the value.
     Condition Predicate LQueryValue LQueryValue
 
     # Serializes an LQuery value to its JSON representation.

--- a/stdlib/Std/src/Time.luna
+++ b/stdlib/Std/src/Time.luna
@@ -294,6 +294,9 @@ class Time:
     # Converts a `Time` to an epoch.
     def toEpoch: self.format "%s"
 
+    # Internal: converts a `Time` to `LQueryValue`.
+    def toLQueryValue: ValTimestampNs $ self.toEpoch.toInt * 1000000000
+
 # A class representing time intervals, that is: a difference between two times.
 # Can be converted to different time resolutions like seconds, miliseconds and microseconds.
 # Internally the time interval is stored with picosecond resolution.


### PR DESCRIPTION
### Pull Request Description
This PR adds support for a new LQuery type: timestamp (stored as ns count since unix epoch start) and conversion from Luna' `Time` type. It is accompanied by a few methods for date components extraction.

### Important Notes
In future some improvements should be made:
* support other time units besides nanoseconds
* `Time` is exactly equivalent to Arrow's timestamp (different resolution + time zone)

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md).
- [x] The code has been tested where possible.

