### PR TITLE
Report errors for duplicate definitions

### DIFF
--- a/passes/src/Luna/Pass/Resolve/ConsResolution.hs
+++ b/passes/src/Luna/Pass/Resolve/ConsResolution.hs
@@ -49,6 +49,8 @@ resolveConstructors positive root = Layer.read @IR.Model root >>= \case
                                          (Layout.unsafeRelayout root)
                                          consRef
                 IR.replace new root
+            Ambiguous conses ->
+                Error.setError (Just $ Error.consAmbiguous n conses) root
             _ -> Error.setError (Just $ Error.consNotFound n) root
     Uni.Unify l r -> do
         resolveConstructors False =<< IR.source l

--- a/passes/src/Luna/Pass/Sourcing/ClassProcessor.hs
+++ b/passes/src/Luna/Pass/Sourcing/ClassProcessor.hs
@@ -18,6 +18,7 @@ import qualified Luna.IR.Layer                         as Layer
 import qualified Luna.Pass                             as Pass
 import qualified Luna.Pass.Attr                        as Attr
 import qualified Luna.Pass.Basic                       as Pass
+import qualified Luna.Pass.Data.Error                  as Error
 import qualified Luna.Pass.Data.Stage                  as TC
 import qualified Luna.Pass.Sourcing.Data.Class         as Class
 import qualified Luna.Pass.Sourcing.Data.Def           as Def
@@ -223,6 +224,10 @@ registerMethod = \modName clsName paramNames map t -> do
                                    $ Layout.unsafeRelayout root
                     IR.replace newRoot root
                     let documented = Documented doc (Def.Body newRoot)
+                    when_ (isJust $ map ^. wrapped . at name) $ do
+                        let error = Error.duplicateMethodDefinition
+                                modName clsName name
+                        Error.setError (Just error) newRoot
                     return $ map & wrapped . at name .~ Just documented
                 _ -> return map
         _ -> return map


### PR DESCRIPTION
### Pull Request Description

This pull request introduces errors for most of duplicate definition scenarios, with one exception. Namely, whenever we have two class definitions without explicit constructors, errors won't be shown at callsite. I'm not sure why is this happening, I tried to set error on Record node, but it seems to be unused for constructor resolution. @kustosz if you could help here, I would greatly appreciate it.
![zrzut ekranu z 2018-09-25 14-12-07](https://user-images.githubusercontent.com/2052578/46013573-00db4980-c0cd-11e8-9609-7eb68ba4cfed.png)

### Important Notes

Error messages are subject to change if you have any improvement requests.

### Checklist
Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md).
- [ ] The code has been tested where possible.

