### PR TITLE
fix Std.Base.Binary.take & .drop

### DIFF
--- a/stdlib/src/Luna/Prim/Base.hs
+++ b/stdlib/src/Luna/Prim/Base.hs
@@ -228,8 +228,8 @@ primBinary = do
     eq <- makeFunctionPure @graph eqVal [Builder.binaryLT, Builder.binaryLT] Builder.boolLT
     plus <- makeFunctionPure @graph plusVal [Builder.binaryLT, Builder.binaryLT] Builder.binaryLT
     len <- makeFunctionPure @graph lenVal [Builder.binaryLT] Builder.intLT
-    take <- makeFunctionPure @graph takeVal [Builder.binaryLT] Builder.binaryLT
-    drop <- makeFunctionPure @graph dropVal [Builder.binaryLT] Builder.binaryLT
+    take <- makeFunctionPure @graph takeVal [Builder.binaryLT, Builder.intLT] Builder.binaryLT
+    drop <- makeFunctionPure @graph dropVal [Builder.binaryLT, Builder.intLT] Builder.binaryLT
     concat <- makeFunctionPure @graph concatVal [Builder.listLT Builder.binaryLT] Builder.binaryLT
     return $ Map.fromList [ ("primBinaryToText",   toText)
                           , ("primBinaryEquals",   eq)


### PR DESCRIPTION
Fix arguments list for builtin functions Std.Base.Binary.take and drop.

Fixes https://github.com/luna/luna-studio/issues/1029.

Please note I wasn't able to test this, as I don't have access to a machine with enough RAM to successfully compile Luna.

