### PR TITLE
Generate default toJSON implementation for classes

### DIFF
--- a/stdlib/StdTest/src/Lang/ToJSONGeneration.luna
+++ b/stdlib/StdTest/src/Lang/ToJSONGeneration.luna
@@ -1,0 +1,47 @@
+import Std.Base
+import Std.Test
+
+class A:
+    a, b :: Int
+
+
+class B:
+    B1:
+        c, d :: Int
+    B2:
+        e, f :: Real
+
+class C:
+    g :: Text
+    def toJSON: "C".toJSON
+
+class ToJSONGenerationTest:
+    def oneConsToJSON:
+        init     = A 1 2
+        actual   = init.toJSON
+        expected = JSON . empty . insert "a" 1 . insert "b" 2
+        TestSubject actual . should (be expected)
+
+    def firstConsToJSON:
+        init     = B1 1 2
+        actual   = init.toJSON
+        expected = JSON . empty . insert "c" 1 . insert "d" 2 . insert "tag" "B1"
+        TestSubject actual . should (be expected)
+
+    def secondConsToJSON:
+        init     = B2 1.0 2.0
+        actual   = init.toJSON
+        expected = JSON . empty . insert "e" 1 . insert "f" 2 . insert "tag" "B2"
+        TestSubject actual . should (be expected)
+
+    def explicitToJSON:
+        init     = C "foo"
+        actual   = init.toJSON
+        expected = JSONString "C"
+        TestSubject actual . should (be expected)
+
+    def run:
+        Test.specify "One constructor class gets default toJSON implementation"           self.oneConsToJSON
+        Test.specify "Multi constructor class has tag in default toJSON implementation"   self.firstConsToJSON
+        Test.specify "Multi constructor class has tag in default toJSON implementation 2" self.secondConsToJSON
+        Test.specify "Explicit toJSON implementation is not replaced with default"        self.explicitToJSON

--- a/stdlib/StdTest/src/Lang/ToJSONGeneration.luna
+++ b/stdlib/StdTest/src/Lang/ToJSONGeneration.luna
@@ -15,6 +15,8 @@ class C:
     g :: Text
     def toJSON: "C".toJSON
 
+class D:
+
 class ToJSONGenerationTest:
     def oneConsToJSON:
         init     = A 1 2
@@ -40,8 +42,15 @@ class ToJSONGenerationTest:
         expected = JSONString "C"
         TestSubject actual . should (be expected)
 
+    def emptyClass:
+        init     = D
+        actual   = init.toJSON
+        expected = JSON.empty
+        TestSubject actual . should (be expected)
+
     def run:
         Test.specify "One constructor class gets default toJSON implementation"           self.oneConsToJSON
         Test.specify "Multi constructor class has tag in default toJSON implementation"   self.firstConsToJSON
         Test.specify "Multi constructor class has tag in default toJSON implementation 2" self.secondConsToJSON
         Test.specify "Explicit toJSON implementation is not replaced with default"        self.explicitToJSON
+        Test.specify "Empty class"                                                        self.emptyClass

--- a/stdlib/StdTest/src/Main.luna
+++ b/stdlib/StdTest/src/Main.luna
@@ -5,6 +5,7 @@ import StdTest.Lang.FieldModifications
 import StdTest.Lang.PatternMatch
 import StdTest.Lang.Recursion
 import StdTest.Lang.SideEffects
+import StdTest.Lang.ToJSONGeneration
 
 import StdTest.Data.List
 import StdTest.Data.Map
@@ -17,6 +18,7 @@ def main:
     PatternMatchTest.run
     RecursionTest.run
     SideEffectsTest.run
+    ToJSONGenerationTest.run
 
     ListTest.run
     MapTest.run


### PR DESCRIPTION
### Pull Request Description

Generate default toJSON method for classes without it.

### Important Notes

Notable change: Luna classes have automatically derived `toJSON` method if not specified.

### Checklist
Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md).
- [ ] The code has been tested where possible.

