### PR TITLE
Include all comments in a docstring instead of only the first line

### DIFF
--- a/syntax/text/parser2/src/Luna/Syntax/Text/Parser/Ast/Spanned.hs
+++ b/syntax/text/parser2/src/Luna/Syntax/Text/Parser/Ast/Spanned.hs
@@ -234,6 +234,11 @@ documented :: Spanned Ast -> Spanned Ast -> Spanned Ast
 documented = inheritSpan2 $ \doc base -> Documented doc base
 {-# INLINE documented #-}
 
+concatComments :: NonEmpty (Spanned Ast) -> Spanned Ast
+concatComments = inheritSpanList1 $ \docs ->
+    Comment $ unlines $ fmap (\(unspan -> Comment t) -> t) docs
+{-# INLINE concatComments #-}
+
 
 
 -----------------------------

--- a/syntax/text/parser2/src/Luna/Syntax/Text/Parser/Parser/Class.hs
+++ b/syntax/text/parser2/src/Luna/Syntax/Text/Parser/Parser/Class.hs
@@ -660,7 +660,9 @@ assertNotComment = \tok -> when_ (isComment $ Ast.unspan tok)
 
 nonBlockExprBody' :: Parser' (Spanned Ast)
 nonBlockExprBody' = documented <|> unusedComment <|> body where
-    documented    = Ast.documented <$> ((\(a:|as) -> a) <$> blockBody1 (satisfyAst isComment)) <*> docBase
+    documented    = Ast.documented
+                <$> (Ast.concatComments <$> blockBody1 (satisfyAst isComment))
+                <*> docBase
     unusedComment = satisfyAst isComment
     docBase       = broken (Indent.indentedEq *> body)
 


### PR DESCRIPTION
### Pull Request Description

Fixes issue with docstrings containing only the first line.

### Checklist
Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md).
- [ ] The code has been tested where possible.

