### PR TITLE
Treat all projects in LUNA_LIBS_PATH as available to import

### DIFF
--- a/package/src/Luna/Package.hs
+++ b/package/src/Luna/Package.hs
@@ -221,7 +221,10 @@ includedLibs = do
                 (\a -> (isUpper <$> head a) == Just True) dirs
         return projects
     for projectNames $ \projectName ->
-        pure (convert projectName, lunaroot <> "/" <> projectName <> "/")
+        pure (convert projectName, lunaroot
+                                    <> FilePath.pathSeparator
+                                    <> projectName
+                                    <> FilePath.pathSeparator)
 
 packageImportPaths :: (MonadIO m, MonadException Path.PathException m)
     => Path Abs Dir -> m [(Name.Name, FilePath.FilePath)]

--- a/package/src/Luna/Package.hs
+++ b/package/src/Luna/Package.hs
@@ -19,7 +19,9 @@ import qualified System.FilePath                  as FilePath
 import qualified System.FilePath.Find             as Find
 
 import Control.Arrow           ((&&&))
+import Control.Monad           (filterM)
 import Control.Monad.Exception (MonadExceptions, MonadException)
+import Data.Char               (isUpper)
 import Data.Bimap              (Bimap)
 import Data.Map                (Map)
 import Path                    (Path, Abs, Rel, File, Dir, (</>))
@@ -207,26 +209,35 @@ listDependencies pkgSrc = Exception.rethrowFromIO @Path.PathException $ do
             pure $ fmap (convert &&& (lunaModulesPath FilePath.</>)) directDeps
                   <> concat indirectDeps
 
+includedLibs :: MonadIO m => m [(Name.Name, FilePath.FilePath)]
+includedLibs = do
+    lunaroot     <- liftIO $ Directory.canonicalizePath
+        =<< Environment.getEnv Name.lunaRootEnv
+    projectNames <- liftIO $ do
+        contents <- Directory.listDirectory lunaroot
+        dirs     <- filterM
+            (\a -> Directory.doesDirectoryExist $ lunaroot FilePath.</> a) contents
+        let projects = filter
+                (\a -> (isUpper <$> head a) == Just True) dirs
+        return projects
+    for projectNames $ \projectName ->
+        pure (convert projectName, lunaroot <> "/" <> projectName <> "/")
+
 packageImportPaths :: (MonadIO m, MonadException Path.PathException m)
     => Path Abs Dir -> m [(Name.Name, FilePath.FilePath)]
 packageImportPaths pkgRoot = do
-    lunaroot     <- liftIO $ Directory.canonicalizePath
-        =<< Environment.getEnv Name.lunaRootEnv
-    dependencies <- listDependencies pkgRoot
-    let importPaths = ("Std", lunaroot <> "/Std/")
-                    : (getPackageName &&& Path.toFilePath) pkgRoot
+    dependencies    <- listDependencies pkgRoot
+    includedImports <- includedLibs
+    let importPaths = (getPackageName &&& Path.toFilePath) pkgRoot
                     : dependencies
-    pure importPaths
+    pure $ includedImports <> importPaths
 
 fileSourcePaths :: (MonadIO m, MonadException Path.PathException m)
     => Path Abs File -> m (Map Name.Qualified FilePath.FilePath)
 fileSourcePaths lunaFile = Exception.rethrowFromIO @Path.PathException $ do
-    lunaRoot <- liftIO $ Directory.canonicalizePath
-        =<< Environment.getEnv Name.lunaRootEnv
     let fileName    = FilePath.dropExtension . Path.fromRelFile
             $ Path.filename lunaFile
-        fileImports :: [(Name.Name, FilePath.FilePath)]
-        fileImports = [("Std", lunaRoot <> "/Std/")]
+    fileImports <- includedLibs
 
     importPaths   <- sequence $ Path.parseAbsDir . snd <$> fileImports
     importSources <- sequence $ findPackageSources <$> importPaths

--- a/package/src/Luna/Package.hs
+++ b/package/src/Luna/Package.hs
@@ -221,10 +221,11 @@ includedLibs = do
                 (\a -> (isUpper <$> head a) == Just True) dirs
         return projects
     for projectNames $ \projectName ->
-        pure (convert projectName, lunaroot
-                                    <> FilePath.pathSeparator
+        let separator = [FilePath.pathSeparator]
+        in pure (convert projectName, lunaroot
+                                    <> separator
                                     <> projectName
-                                    <> FilePath.pathSeparator)
+                                    <> separator)
 
 packageImportPaths :: (MonadIO m, MonadException Path.PathException m)
     => Path Abs Dir -> m [(Name.Name, FilePath.FilePath)]

--- a/stdlib/package.yaml
+++ b/stdlib/package.yaml
@@ -40,6 +40,7 @@ dependencies:
     - libffi
     - luna-core
     - luna-passes
+    - luna-package
     - luna-runtime
     - luna-syntax-text-prettyprint
     - mtl


### PR DESCRIPTION
### Pull Request Description

This pull request causes Luna to treat all projects located at LUNA_LIBS_PATH as available to import. It was done to prepare a package with Dataframes embedded and seems to work as intended on Windows.

### Important Notes

Projects discovery is rather simple, treating all directories starting with capital letter as Luna projects.

### Checklist
Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md).
- [ ] The code has been tested where possible.

