### PR TITLE
Hack previous parser behaviour for AccSection

### DIFF
--- a/syntax/text/parser3/src/Luna/Pass/Parsing/Parser.hs
+++ b/syntax/text/parser3/src/Luna/Pass/Parsing/Parser.hs
@@ -313,7 +313,15 @@ buildIR = \(Spanned cs ast) -> addCodeSpan cs =<< case ast of
                     rIsNum = isNumber r
                 in dot && lIsNum && rIsNum
 
-            -- luna/luna#301
+            -- The old parser translates a .foo.bar to application
+            -- between Var "a" and AccSection ["foo", "bar"], a core
+            -- constructor of form AccSection { path :: Vec16 Name }.
+            -- The constructor is deprecated, as it supports only named
+            -- sections and discards information about code spans.
+            -- The real solution should be implemented in passes,
+            -- probably in desugaring, as this situation is very similar
+            -- to wildcard handling.
+            -- See luna/luna#301 for more info
             hackAccSection left op = do
                 let noHack = do
                         r' <- buildIR $! Ast.prependAsOffset f r

--- a/syntax/text/parser3/src/Luna/Pass/Parsing/Parser.hs
+++ b/syntax/text/parser3/src/Luna/Pass/Parsing/Parser.hs
@@ -297,6 +297,7 @@ buildIR = \(Spanned cs ast) -> addCodeSpan cs =<< case ast of
 
     Ast.InfixApp l f r -> do
         let tok = Ast.unspan f
+            dot = tok == Ast.Operator Name.acc
             specialOp = case tok of
                 Ast.Operator op -> if
                     | op == Name.assign -> Just IR.unify'
@@ -305,13 +306,30 @@ buildIR = \(Spanned cs ast) -> addCodeSpan cs =<< case ast of
                     | otherwise         -> Nothing
                 _ -> Nothing
             realNumber =
-                let dot = tok == Ast.Operator Name.acc
-                    isNumber ast = case Ast.unspan ast of
+                let isNumber ast = case Ast.unspan ast of
                         Ast.Number _ -> True
                         _            -> False
                     lIsNum = isNumber l
                     rIsNum = isNumber r
                 in dot && lIsNum && rIsNum
+
+            -- luna/luna#301
+            hackAccSection left op = do
+                let noHack = do
+                        r' <- buildIR $! Ast.prependAsOffset f r
+                        op left r'
+                if dot then do
+                    Layer.read @IR.Model left >>= \case
+                        Uni.AccSection accSec' -> do
+                            case Ast.unspan r of
+                                Ast.Var r' -> do
+                                    oldSection <- Mutable.toList accSec'
+                                    newSection <- Mutable.fromList
+                                        (oldSection <> [r'])
+                                    IR.accSection' newSection
+                                _ -> noHack
+                        _ -> noHack
+                else noHack
 
         case specialOp of
             Just op -> do
@@ -319,8 +337,7 @@ buildIR = \(Spanned cs ast) -> addCodeSpan cs =<< case ast of
                     buildRealIR l r
                 else do
                     l' <- buildIR l
-                    r' <- buildIR $! Ast.prependAsOffset f r
-                    op l' r'
+                    hackAccSection l' op
             Nothing -> do
                 f' <- buildIR f
                 l' <- buildIR l

--- a/syntax/text/parser3/test/spec/Luna/Test/Source/Text/ParserSpec.hs
+++ b/syntax/text/parser3/test/spec/Luna/Test/Source/Text/ParserSpec.hs
@@ -81,10 +81,16 @@ unitSpec :: Spec
 unitSpec = describe "unit" $ do
     it "empty" $ e_x "" ""
 
+accSectionSpec :: Spec
+accSectionSpec = describe "acc section" $ do
+    ite "[1,2,3].each .succ.pred"         "[1, 2, 3] . each .succ.pred"
+    ite "[1,2,3].each .succ.pred.foo"     "[1, 2, 3] . each .succ.pred.foo"
+    ite "[1,2,3].each .succ.pred.foo.bar" "[1, 2, 3] . each .succ.pred.foo.bar"
+
 debugSpec :: Spec
 debugSpec = xdescribe "error" $ it "debug" $ do
 
-    let input = [qqStr|.asText|]
+    let input = [qqStr|a .succ.pred.foo|]
 
     putStrLn "\n\n"
     pprint $ PP.evalVersion1With Macro.unit (convert input)
@@ -102,5 +108,6 @@ spec = do
     functionDefSpec
     caseSpec
     unitSpec
+    accSectionSpec
 
     debugSpec


### PR DESCRIPTION
### Pull Request Description

Restore previous behaviour in regard to parsing AccSections as defined in #301 

### Important Notes

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md).
- [x] The code has been tested where possible.

