### PR TITLE
Fix Package Renaming + Add Rename Command

### DIFF
--- a/package/src/Luna/Package.hs
+++ b/package/src/Luna/Package.hs
@@ -305,6 +305,8 @@ rename src target = Exception.rethrowFromIO @Path.PathException $ do
     let origProjPath = target </> Name.configDirectory </> origProjFile
         newProjPath  = target </> Name.configDirectory </> newProjFile
 
+    -- TODO [Ara] Use Directory.copyFile
+
     liftIO $ Directory.renameFile (Path.fromAbsFile origProjPath)
         (Path.fromAbsFile newProjPath)
 

--- a/package/src/Luna/Package.hs
+++ b/package/src/Luna/Package.hs
@@ -219,7 +219,7 @@ includedLibs = do
             (\a -> Directory.doesDirectoryExist $ lunaroot FilePath.</> a) contents
         let projects = filter
                 (\a -> (isUpper <$> head a) == Just True) dirs
-        return projects
+        pure projects
     for projectNames $ \projectName ->
         let separator = [FilePath.pathSeparator]
         in pure (convert projectName, lunaroot

--- a/package/src/Luna/Package/Utilities.hs
+++ b/package/src/Luna/Package/Utilities.hs
@@ -1,0 +1,20 @@
+module Luna.Package.Utilities where
+
+import Prologue
+
+
+
+-------------------------------
+-- === Utility Functions === --
+-------------------------------
+
+-- === API === --
+
+-- from package `extra` with BSD3 licence
+partitionM :: Monad m => (a -> m Bool) -> [a] -> m ([a],[a])
+partitionM f [] = pure ([],[])
+partitionM f (x:xs) = do
+    res <- f x
+    (as, bs) <- partitionM f xs
+    pure ([x | res] <> as, [x | not res] <> bs)
+

--- a/package/test/spec/Luna/PackageSpec.hs
+++ b/package/test/spec/Luna/PackageSpec.hs
@@ -41,9 +41,6 @@ shouldFailWithName name = Temp.withSystemTempDirectory "pkgTest" $ \dir ->
                 origPath <- Path.parseAbsDir path
                 newPath  <- Path.parseAbsDir (dir </> name)
 
-                let renameException :: Selector Package.RenameException
-                    renameException = const True
-
                 Package.rename origPath newPath `shouldThrow` renameException
 
 hasName :: Local.Config -> Text -> Expectation
@@ -79,6 +76,9 @@ shouldRenameWith name = Temp.withSystemTempDirectory "pkgTest" $ \dir ->
 
                 projExists <- Directory.doesFileExist projPath
                 projExists `shouldBe` True
+
+renameException :: Selector Package.RenameException
+renameException = const True
 
 
 

--- a/shell/src/Luna/Shell/Command.hs
+++ b/shell/src/Luna/Shell/Command.hs
@@ -252,11 +252,15 @@ rename opts = MException.rethrowFromIO @Path.PathException
         putStrLn $ "Package renamed to " <> Path.fromAbsDir resultPath
 
     where printErr :: Package.RenameException -> IO ()
-          printErr e = case e of
-              Package.InvalidName       tx   -> undefined
-              Package.InaccessiblePath  path -> undefined
-              Package.InaccessibleFile  path -> undefined
-              Package.DestinationExists path -> undefined
+          printErr e = hPutStrLn stderr $ case e of
+              Package.InvalidName       tx   -> convert tx
+                  <> " is not a valid package name."
+              Package.InaccessiblePath  path -> Path.fromAbsDir path
+                  <> " is not accessible."
+              Package.InaccessibleFile  path -> Path.fromAbsFile path
+                  <> " can't be found."
+              Package.DestinationExists path -> "Destination "
+                  <> Path.fromAbsDir path <> " already exists."
 
           getPath :: FilePath -> IO (Path Abs Dir)
           getPath fp = MException.rethrowFromIO @Path.PathException $ do

--- a/shell/src/Luna/Shell/Command.hs
+++ b/shell/src/Luna/Shell/Command.hs
@@ -263,6 +263,7 @@ rename opts = MException.catch printRenameEx . MException.catch printPNFEx $ do
                 <> Path.fromAbsDir path <> " already exists."
             Package.CannotDelete      path -> "Unable to delete "
                 <> Path.fromAbsDir path
+            Package.CannotRenameFile file -> "Cannot rename " <> show file
 
         printPNFEx :: (MonadIO n, MonadException Package.RenameException n)
             => Package.PackageNotFoundException -> n ()

--- a/shell/src/Luna/Shell/Command.hs
+++ b/shell/src/Luna/Shell/Command.hs
@@ -253,7 +253,7 @@ rename opts = MException.catch printRenameEx . MException.catch printPNFEx $ do
     where
         printRenameEx :: Package.RenameException -> m ()
         printRenameEx e = liftIO . hPutStrLn stderr $ case e of
-            Package.InvalidName       tx   -> convert tx
+            Package.InvalidName       tx   -> "\"" <> convert tx <> "\""
                 <> " is not a valid package name."
             Package.InaccessiblePath  path -> Path.fromAbsDir path
                 <> " is not accessible."

--- a/shell/src/Luna/Shell/Command.hs
+++ b/shell/src/Luna/Shell/Command.hs
@@ -252,27 +252,11 @@ rename opts = MException.catch printRenameEx . MException.catch printPNFEx $ do
 
     where
         printRenameEx :: Package.RenameException -> m ()
-        printRenameEx e = liftIO . hPutStrLn stderr $ case e of
-            Package.InvalidName       tx   -> "\"" <> convert tx <> "\""
-                <> " is not a valid package name."
-            Package.InaccessiblePath  path -> Path.fromAbsDir path
-                <> " is not accessible."
-            Package.InaccessibleFile  path -> Path.fromAbsFile path
-                <> " can't be found."
-            Package.DestinationExists path -> "Destination "
-                <> Path.fromAbsDir path <> " already exists."
-            Package.CannotDelete      path -> "Unable to delete "
-                <> Path.fromAbsDir path
-            Package.CannotRenameFile file -> "Cannot rename " <> show file
+        printRenameEx e = liftIO . hPutStrLn stderr $ displayException e
 
         printPNFEx :: (MonadIO n, MonadException Package.RenameException n)
             => Package.PackageNotFoundException -> n ()
-        printPNFEx e = liftIO . hPutStrLn stderr $ case e of
-            Package.PackageNotFound path -> "Package file "
-                <> Path.fromAbsFile path <> " not found."
-            Package.PackageRootNotFound path -> "Package root "
-                <> Path.fromAbsDir path <> " not found."
-            Package.FSError msg -> "Filesystem Error: " <> msg
+        printPNFEx e = liftIO . hPutStrLn stderr $ displayException e
 
         getPath :: (MonadIO n, MonadException Path.PathException n)
             => FilePath -> n (Path Abs Dir)

--- a/shell/src/Luna/Shell/Command.hs
+++ b/shell/src/Luna/Shell/Command.hs
@@ -64,6 +64,13 @@ data InitOpts = InitOpts
     } deriving (Eq, Generic, Ord, Show)
 makeLenses ''InitOpts
 
+-- TODO [Ara] Add a rename command (with optional --source parameter)
+
+data RenameOpts = RenameOpts
+    { _destName :: String
+    , _srcName  :: String
+    } deriving (Eq, Generic, Ord, Show)
+
 data BuildOpts = BuildOpts
     { __acquireDeps        :: Bool
     , __cleanBuild         :: Bool
@@ -137,6 +144,7 @@ data Command
     | Install InstallOpts
     | Options OptionOpts
     | Publish PublishOpts
+    | Rename RenameOpts
     | Retract RetractOpts
     | Rollback RollbackOpts
     | Run RunOpts
@@ -228,6 +236,9 @@ version = putStrLn versionMsg where
         <> "]"
     isDirty = if GitHash.giDirty gitInfo then "Dirty" else "Clean"
 
+rename :: (MonadIO m) => RenameOpts -> m ()
+rename _ = putStrLn "Renaming package"
+
 
 
 -------------------------
@@ -269,6 +280,7 @@ runLuna input = case input of
                     "Setting compiler options is not yet implemented."
                 Publish  _    -> putStrLn
                     "Publishing packages is not yet implemented."
+                Rename opts   -> rename opts
                 Retract  _    -> putStrLn
                     "Retraction of package versions is not yet implemented."
                 Rollback _    -> putStrLn

--- a/shell/src/Luna/Shell/Option.hs
+++ b/shell/src/Luna/Shell/Option.hs
@@ -66,9 +66,9 @@ init = Command.Init <$> (Command.InitOpts
 rename :: Parser Command
 rename = Command.Rename <$> ( Command.RenameOpts
     <$> Options.argument Options.str (Options.metavar "PACKAGE-NAME")
-    <*> Options.strOption (Options.long "target"
+    <*> Options.strOption (Options.long "source"
         <> Options.metavar "PATH" <> Options.value ""
-        <> Options.help "Move the target package."))
+        <> Options.help "Move the source package instead of the current one."))
 
 build :: Parser Command
 build = Command.Build <$> (Command.BuildOpts

--- a/shell/src/Luna/Shell/Option.hs
+++ b/shell/src/Luna/Shell/Option.hs
@@ -33,7 +33,9 @@ lunaCommand = Command.Exec <$> Options.hsubparser
     <> Options.command "init" (Options.info init
         (Options.progDesc "Initialise a new luna package."))
     <> Options.command "document" (Options.info document
-        (Options.progDesc "Print documentation in JSON format.")))
+        (Options.progDesc "Print documentation in JSON format."))
+    <> Options.command "rename" (Options.info rename
+        (Options.progDesc "Rename a package.")))
 
 run :: Parser Command
 run = Command.Run <$> (Command.RunOpts
@@ -51,7 +53,7 @@ document = Command.Document <$> (Command.DocumentOpts
         <> Options.help "Specify the output file"))
 
 init :: Parser Command
-init = Command.Init <$> ( Command.InitOpts
+init = Command.Init <$> (Command.InitOpts
     <$> Options.argument Options.str (Options.metavar "PACKAGE-NAME")
     <*> Options.strOption (Options.long "luna-version"
         <> Options.metavar "VERSION" <> Options.value ""
@@ -60,6 +62,13 @@ init = Command.Init <$> ( Command.InitOpts
     <*> Options.strOption (Options.long "license"
         <> Options.metavar "LICENSE" <> Options.value ""
         <> Options.help "Initialise the package with the specified license."))
+
+rename :: Parser Command
+rename = Command.Rename <$> ( Command.RenameOpts
+    <$> Options.argument Options.str (Options.metavar "PACKAGE-NAME")
+    <*> Options.strOption (Options.long "target"
+        <> Options.metavar "PATH" <> Options.value ""
+        <> Options.help "Move the target package."))
 
 build :: Parser Command
 build = Command.Build <$> (Command.BuildOpts

--- a/shell/src/Luna/Shell/Option.hs
+++ b/shell/src/Luna/Shell/Option.hs
@@ -65,10 +65,8 @@ init = Command.Init <$> (Command.InitOpts
 
 rename :: Parser Command
 rename = Command.Rename <$> ( Command.RenameOpts
-    <$> Options.argument Options.str (Options.metavar "PACKAGE-NAME")
-    <*> Options.strOption (Options.long "source"
-        <> Options.metavar "PATH" <> Options.value ""
-        <> Options.help "Move the source package instead of the current one."))
+    <$> Options.argument Options.str (Options.metavar "SOURCE-NAME")
+    <*> Options.argument Options.str (Options.metavar "DEST-NAME"))
 
 build :: Parser Command
 build = Command.Build <$> (Command.BuildOpts


### PR DESCRIPTION
### Pull Request Description
This PR fixes #303, and the error reported in [luna-studio/#1025](https://github.com/luna/luna-studio/issues/1025). It also introduces a command-line `rename` command that utilises the same functionality. 

### Important Notes

- The bugfix changed a 'move' operation to a 'copy' operation to work across device boundaries. 
- The new command simply accepts a source and destination project name. 

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md).
- [x] The code has been tested where possible.

