### PR TITLE
Bump Stackage Snapshot

### DIFF
--- a/config/snapshot-local.yaml
+++ b/config/snapshot-local.yaml
@@ -1,7 +1,8 @@
-resolver: nightly-2018-05-30
+resolver: lts-12.16
 name: luna-local
 packages:
     - hspec-expectations-lifted-0.10.0
     - megaparsec-6.5.0
     - placeholders-0.1
     - githash-0.1.0.1
+

--- a/config/snapshot-local.yaml
+++ b/config/snapshot-local.yaml
@@ -1,8 +1,14 @@
 resolver: lts-12.16
 name: luna-local
 packages:
-    - hspec-expectations-lifted-0.10.0
-    - megaparsec-6.5.0
-    - placeholders-0.1
+    - authenticate-oauth-1.6
     - githash-0.1.0.1
+    - hspec-expectations-lifted-0.10.0
+    - hspec-megaparsec-2.0.0
+    - megaparsec-6.5.0
+    - perf-0.4.1.0
+    - placeholders-0.1
+    - rdtsc-1.3.0.1
+    - storable-tuple-0.0.3.3
+    - wuss-1.1.10
 

--- a/config/snapshot-local.yaml
+++ b/config/snapshot-local.yaml
@@ -1,14 +1,8 @@
 resolver: lts-12.16
 name: luna-local
 packages:
-    - authenticate-oauth-1.6
     - githash-0.1.0.1
     - hspec-expectations-lifted-0.10.0
-    - hspec-megaparsec-2.0.0
     - megaparsec-6.5.0
-    - perf-0.4.1.0
     - placeholders-0.1
-    - rdtsc-1.3.0.1
-    - storable-tuple-0.0.3.3
-    - wuss-1.1.10
 

--- a/config/snapshot.yaml
+++ b/config/snapshot.yaml
@@ -1,23 +1,30 @@
-resolver: lts-12.16
+resolver: nightly-2018-10-31
 name: luna
 packages:
-- container-1.1.5
-- convert-1.5
-- functor-utils-1.17.1
-- githash-0.1.0.1
-- hspec-expectations-lifted-0.10.0
-- impossible-1.1.3
-- layered-state-1.1.4
-- layouting-1.1.3
-- lens-utils-1.4.5
-- megaparsec-6.5.0
-- monad-branch-1.0.3
-- monoid-0.1.8
-- placeholders-0.1
-- prologue-3.2.4
-- terminal-text-1.1.1
-- typelevel-1.2.2
-- vector-text-1.1.5
-- git: "git@github.com:fpco/weigh.git"
-  commit: aabc37b4a4d9cc2fed236714e345394a60a18310
+    - authenticate-oauth-1.6
+    - container-1.1.5
+    - convert-1.5
+    - functor-utils-1.17.1
+    - githash-0.1.0.1
+    - hspec-expectations-lifted-0.10.0
+    - hspec-megaparsec-2.0.0
+    - impossible-1.1.3
+    - layered-state-1.1.4
+    - layouting-1.1.3
+    - lens-utils-1.4.5
+    - megaparsec-6.5.0
+    - monad-branch-1.0.3
+    - monoid-0.1.8
+    - perf-0.4.1.0
+    - placeholders-0.1
+    - prologue-3.2.4
+    - rdtsc-1.3.0.1
+    - storable-tuple-0.0.3.3
+    - terminal-text-1.1.1
+    - typelevel-1.2.2
+    - vector-text-1.1.5
+    - wuss-1.1.10
+
+    - git: "git@github.com:fpco/weigh.git"
+      commit: aabc37b4a4d9cc2fed236714e345394a60a18310
 

--- a/config/snapshot.yaml
+++ b/config/snapshot.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2018-05-30
+resolver: lts-12.16
 name: luna
 packages:
 - container-1.1.5

--- a/config/snapshot.yaml
+++ b/config/snapshot.yaml
@@ -1,30 +1,23 @@
-resolver: nightly-2018-10-31
+resolver: lts-12.16
 name: luna
 packages:
-    - authenticate-oauth-1.6
-    - container-1.1.5
-    - convert-1.5
-    - functor-utils-1.17.1
-    - githash-0.1.0.1
-    - hspec-expectations-lifted-0.10.0
-    - hspec-megaparsec-2.0.0
-    - impossible-1.1.3
-    - layered-state-1.1.4
-    - layouting-1.1.3
-    - lens-utils-1.4.5
-    - megaparsec-6.5.0
-    - monad-branch-1.0.3
-    - monoid-0.1.8
-    - perf-0.4.1.0
-    - placeholders-0.1
-    - prologue-3.2.4
-    - rdtsc-1.3.0.1
-    - storable-tuple-0.0.3.3
-    - terminal-text-1.1.1
-    - typelevel-1.2.2
-    - vector-text-1.1.5
-    - wuss-1.1.10
-
-    - git: "git@github.com:fpco/weigh.git"
-      commit: aabc37b4a4d9cc2fed236714e345394a60a18310
+- container-1.1.5
+- convert-1.5
+- functor-utils-1.17.1
+- githash-0.1.0.1
+- hspec-expectations-lifted-0.10.0
+- impossible-1.1.3
+- layered-state-1.1.4
+- layouting-1.1.3
+- lens-utils-1.4.5
+- megaparsec-6.5.0
+- monad-branch-1.0.3
+- monoid-0.1.8
+- placeholders-0.1
+- prologue-3.2.4
+- terminal-text-1.1.1
+- typelevel-1.2.2
+- vector-text-1.1.5
+- git: "git@github.com:fpco/weigh.git"
+  commit: aabc37b4a4d9cc2fed236714e345394a60a18310
 

--- a/package/test/spec/Luna/Package/Configuration/GlobalSpec.hs
+++ b/package/test/spec/Luna/Package/Configuration/GlobalSpec.hs
@@ -19,7 +19,7 @@ license:
   default-license: mit
   generate-license: true
 compiler:
-  version: '1.3.5'
+  version: 1.3.5
   options:
   - Foo
   - Bar


### PR DESCRIPTION
### Pull Request Description
Bump the stackage snapshot. Currently limited to `lts-12.16` due to dependencies not being updated enough yet.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md).
- [x] The code has been tested where possible.

