### PR TITLE
Generate Package Config if Missing for Backwards Compat

### DIFF
--- a/config/snapshot.yaml
+++ b/config/snapshot.yaml
@@ -1,23 +1,25 @@
 resolver: lts-12.16
 name: luna
 packages:
-- container-1.1.5
-- convert-1.5
-- functor-utils-1.17.1
-- githash-0.1.0.1
-- hspec-expectations-lifted-0.10.0
-- impossible-1.1.3
-- layered-state-1.1.4
-- layouting-1.1.3
-- lens-utils-1.4.5
-- megaparsec-6.5.0
-- monad-branch-1.0.3
-- monoid-0.1.8
-- placeholders-0.1
-- prologue-3.2.4
-- terminal-text-1.1.1
-- typelevel-1.2.2
-- vector-text-1.1.5
-- git: "git@github.com:fpco/weigh.git"
-  commit: aabc37b4a4d9cc2fed236714e345394a60a18310
+    - container-1.1.5
+    - convert-1.5
+    - functor-utils-1.17.1
+    - githash-0.1.0.1
+    - hspec-expectations-lifted-0.10.0
+    - impossible-1.1.3
+    - intero-0.1.34
+    - layered-state-1.1.4
+    - layouting-1.1.3
+    - lens-utils-1.4.5
+    - megaparsec-6.5.0
+    - monad-branch-1.0.3
+    - monoid-0.1.8
+    - placeholders-0.1
+    - prologue-3.2.4
+    - terminal-text-1.1.1
+    - typelevel-1.2.2
+    - vector-text-1.1.5
+
+    - git: "git@github.com:fpco/weigh.git"
+      commit: aabc37b4a4d9cc2fed236714e345394a60a18310
 

--- a/package/src/Luna/Package.hs
+++ b/package/src/Luna/Package.hs
@@ -333,6 +333,8 @@ rename src target = do
             Exception.throw $ CannotDelete src e)
         . liftIO $ Directory.removeDirectoryRecursive srcPath
 
+    -- TODO [Ara] Create file if missing.
+
     -- Rename the `*.lunaproject` file
     origProjFile <- Exception.rethrowFromIO @Path.PathException
         . Path.parseRelFile $ convert originalName <> Name.packageExt
@@ -347,6 +349,8 @@ rename src target = do
             Exception.throw $ CannotRenameFile newProjPath e)
         . liftIO $ Directory.renameFile (Path.fromAbsFile origProjPath)
         (Path.fromAbsFile newProjPath)
+
+    -- TODO [Ara] Create file if missing.
 
     -- Change the name in the `config.yaml` file
     configName <- Exception.rethrowFromIO @Path.PathException

--- a/package/src/Luna/Package/Structure/Generate/Internal.hs
+++ b/package/src/Luna/Package/Structure/Generate/Internal.hs
@@ -99,11 +99,6 @@ generateConfigDir pkgPath mLicense globalCfg = do
         authorMail = globalCfg ^. Global.user . Global.email
         maintainer = if Text.null authorMail then "" else
             authorName <> " <" <> authorMail <> ">"
-        initConfig = (def @Local.Config)
-            & Local.license     .~ (fromJust License.None mLicense)
-            & Local.projectName .~ (convert pkgName)
-            & Local.author      .~ authorName
-            & Local.maintainer  .~ maintainer
         pkgName    = unsafeLast $ FilePath.splitDirectories pkgPath
         -- By this point it is guaranteed to have a valid name
 
@@ -112,8 +107,18 @@ generateConfigDir pkgPath mLicense globalCfg = do
     IO.appendFile (configPath </> Name.depsFile) ""
     IO.appendFile (configPath </> Name.depsHistFile) ""
 
+    packageConfig mLicense pkgName authorName maintainer configPath
+
+packageConfig :: Maybe License -> FilePath -> Text -> Text -> FilePath -> IO ()
+packageConfig mLicense pkgName authorName maintainer path = do
+    let initConfig = (def @Local.Config)
+            & Local.license     .~ (fromJust License.None mLicense)
+            & Local.projectName .~ (convert pkgName)
+            & Local.author      .~ authorName
+            & Local.maintainer  .~ maintainer
+
     -- Write the project configuration
-    Yaml.encodeFile (configPath </> Name.configFile) initConfig
+    Yaml.encodeFile (path </> Name.configFile) initConfig
 
 generateDistributionDir :: FilePath -> IO ()
 generateDistributionDir pkgPath = do

--- a/package/src/Luna/Package/Structure/Generate/Internal.hs
+++ b/package/src/Luna/Package/Structure/Generate/Internal.hs
@@ -17,6 +17,7 @@ import qualified System.FilePath                         as FilePath
 import qualified System.IO                               as IO
 import qualified System.IO.Error                         as Exception
 
+import Control.Exception                  (IOException)
 import Luna.Package.Configuration.License (License)
 import System.FilePath                    (FilePath, (</>))
 
@@ -31,8 +32,15 @@ import System.FilePath                    (FilePath, (</>))
 data GeneratorError
     = InvalidPackageLocation FilePath
     | InvalidPackageName Text
-    | SystemError Text
-    deriving (Eq, Generic, Ord, Show)
+    | SystemError IOException
+    deriving (Eq, Generic, Show)
+
+instance Exception GeneratorError where
+    displayException (InvalidPackageLocation fp) = fp
+        <> " is an invalid location for a package."
+    displayException (InvalidPackageName name) = convert name
+        <> " is not a valid package name."
+    displayException (SystemError ex) = "System Error: " <> displayException ex
 
 
 -- === API === --
@@ -42,38 +50,10 @@ recovery :: FilePath -> Exception.IOException
 recovery canonicalName ex = do
     pkgDirExists <- Directory.doesDirectoryExist canonicalName
 
-    let canonicalText :: Text
-        canonicalText = convert canonicalName
+    unless_ (Exception.ioeGetErrorType ex == Exception.AlreadyExists)
+        . when pkgDirExists $ Directory.removeDirectoryRecursive canonicalName
 
-    if Exception.ioeGetErrorType ex == Exception.AlreadyExists then
-        pure . Left . SystemError
-            $ "The package at " <> canonicalText <> " already exists."
-    else do
-        when pkgDirExists $ Directory.removeDirectoryRecursive canonicalName
-
-        let errMsg :: Text
-            errMsg = case Exception.ioeGetErrorType ex of
-                Exception.NoSuchThing -> "No path to the package directory: "
-                    <> canonicalText
-                Exception.ResourceBusy ->
-                    "Cannot create package on busy media. Please try again."
-                Exception.ResourceExhausted -> "Not enough space to create: "
-                    <> canonicalText
-                Exception.PermissionDenied ->
-                    "You do not have permission to create the package: "
-                    <> canonicalText
-                Exception.HardwareFault -> "Hardware Fault: Please try again."
-                Exception.AlreadyExists ->
-                    "Some portion of the package already exists: "
-                    <> canonicalText
-                Exception.InvalidArgument -> "Internal error"
-                Exception.InappropriateType ->
-                    "Some portion of the package already exists: "
-                    <> canonicalText
-                Exception.UnsatisfiedConstraints -> "Internal error"
-                _ -> convert $ show ex
-
-        pure . Left $ SystemError errMsg
+    pure . Left $ SystemError ex
 
 
 -- === Instances === --
@@ -82,7 +62,8 @@ instance StyledShow PrettyShowStyle GeneratorError where
     styledShow _ (InvalidPackageLocation loc) =
         "Cannot create package inside another package at " <> convert loc
     styledShow _ (InvalidPackageName name) = "Invalid name: " <> name
-    styledShow _ (SystemError tx) = "System Error: " <> tx
+    styledShow _ (SystemError ex) = "System Error: " <> convert
+        (displayException ex)
 
 
 

--- a/package/test/spec/Luna/PackageSpec.hs
+++ b/package/test/spec/Luna/PackageSpec.hs
@@ -94,8 +94,8 @@ movesAcrossDevicesTo newPathPart = Temp.withSystemTempDirectory "test" $ \src ->
 
             renameAndCheck name origPath newPath
 
-renameCreatesConfig :: FilePath -> Expectation
-renameCreatesConfig name = Temp.withSystemTempDirectory "test" $ \src ->
+renameMakesConfigIfMissing :: FilePath -> Expectation
+renameMakesConfigIfMissing name = Temp.withSystemTempDirectory "test" $ \src ->
     genPackageStructure (src </> packageName) (Just License.MIT) def >>= \case
         Left _     -> True `shouldBe` False
         Right path -> do
@@ -127,7 +127,8 @@ spec = do
         it "successfully renames a package" $ shouldRenameWith packageNewName
 
     describe "Backwards compatibility when renaming" $
-        it "creates config.yaml if missing" $ renameCreatesConfig "PkgTest"
+        it "creates config.yaml if missing"
+            $ renameMakesConfigIfMissing "PkgTest"
 
     describe "Renaming across devices" $
         it "moves successfully across filesystems" $ do

--- a/package/test/spec/Luna/PackageSpec.hs
+++ b/package/test/spec/Luna/PackageSpec.hs
@@ -2,6 +2,7 @@ module Luna.PackageSpec where
 
 import Prologue
 
+import qualified Control.Exception                  as Exception
 import qualified Data.Yaml                          as Yaml
 import qualified Luna.Package                       as Package
 import qualified Luna.Package.Configuration.Global  as Global
@@ -37,7 +38,7 @@ shouldFailWithName :: FilePath -> Expectation
 shouldFailWithName name = Temp.withSystemTempDirectory "pkgTest" $ \dir ->
     genPackageStructure (dir </> packageName) (Just License.MIT)
         (def @Global.Config) >>= \case
-            Left _     -> True `shouldBe` False
+            Left ex    -> Exception.throw ex
             Right path -> do
                 origPath <- Path.parseAbsDir path
                 newPath  <- Path.parseAbsDir (dir </> name)
@@ -51,7 +52,7 @@ shouldRenameWith :: FilePath -> Expectation
 shouldRenameWith name = Temp.withSystemTempDirectory "pkgTest" $ \dir ->
     genPackageStructure (dir </> packageName) (Just License.MIT)
         (def @Global.Config) >>= \case
-            Left _ -> True `shouldBe` False
+            Left ex    -> Exception.throw ex
             Right path -> do
                 origPath <- Path.parseAbsDir path
                 newPath  <- Path.parseAbsDir (dir </> name)
@@ -85,7 +86,7 @@ renameAndCheck name origPath newPath = do
 movesAcrossDevicesTo :: FilePath -> Expectation
 movesAcrossDevicesTo newPathPart = Temp.withSystemTempDirectory "test" $ \src ->
     genPackageStructure (src </> packageName) (Just License.MIT) def >>= \case
-        Left _     -> True `shouldBe` False
+        Left ex    -> Exception.throw ex
         Right path -> Temp.withTempDirectory newPathPart "test" $ \dest -> do
             let name = "NewName"
 
@@ -97,7 +98,7 @@ movesAcrossDevicesTo newPathPart = Temp.withSystemTempDirectory "test" $ \src ->
 renameMakesConfigIfMissing :: FilePath -> Expectation
 renameMakesConfigIfMissing name = Temp.withSystemTempDirectory "test" $ \src ->
     genPackageStructure (src </> packageName) (Just License.MIT) def >>= \case
-        Left _     -> True `shouldBe` False
+        Left ex    -> Exception.throw ex
         Right path -> do
             -- Remove the *.lunaproject file
             let projPath = path </> Path.fromRelDir Name.configDirectory

--- a/shell/src/Luna/Shell/Command.hs
+++ b/shell/src/Luna/Shell/Command.hs
@@ -211,12 +211,7 @@ init opts = do
             $ view licenseOverride opts
 
     Generate.genPackageStructure (view name opts) mLicense globalCfg >>= \case
-        Left err -> case err of
-            Generate.InvalidPackageLocation msg -> putStrLn msg
-            Generate.InvalidPackageName _       -> putStrLn
-                $ view name opts <> " is not a valid package name."
-            Generate.SystemError msg -> putStrLn
-                $ "System Error: " <> convert msg
+        Left err -> liftIO . hPutStrLn stderr $ displayException err
         Right projectPath -> putStrLn
             $ "Initialised package at " <> projectPath
 


### PR DESCRIPTION
### Pull Request Description
The rename functionality was relying on the existence of a pre-existing `config.yaml` in the package structure. This was a change from the very first Luna package format, but the renamer wasn't taking that into account. It now generates a stub config file if it is missing when renaming a package.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md).
- [x] The code has been tested where possible.

