### PR TITLE
Change error behaviour of rename

### DIFF
--- a/package/src/Luna/Package.hs
+++ b/package/src/Luna/Package.hs
@@ -284,7 +284,7 @@ rename :: ( MonadIO m
           , MonadExceptions '[ PackageNotFoundException
                              , RenameException
                              , Path.PathException] m )
-    => Path Abs Dir -> Path Abs Dir -> m (Path Abs Dir)
+    => Path Abs Dir -> Path Abs Dir -> m (Path Abs Dir, Maybe RenameException)
 rename src target = do
     let srcPath  = Path.fromAbsDir src
         destPath = Path.fromAbsDir target
@@ -330,6 +330,7 @@ rename src target = do
         let relPath = FilePath.makeRelative srcPath file
         liftIO . Directory.copyFile file $ destPath `FilePath.combine` relPath
 
+    -- TODO [Ara] Make this fail late with Either.
     Exception.catchAll (\(e :: SomeException) ->
             Exception.throw $ CannotDelete src e)
         . liftIO $ Directory.removeDirectoryRecursive srcPath
@@ -364,5 +365,5 @@ rename src target = do
         Right cfg -> liftIO . Yaml.encodeFile (Path.fromAbsFile configPath) $
             cfg & Local.projectName .~ newName
 
-    pure target
+    pure (target, Nothing)
 

--- a/package/test/spec/Luna/PackageSpec.hs
+++ b/package/test/spec/Luna/PackageSpec.hs
@@ -62,7 +62,7 @@ shouldRenameWith name = Temp.withSystemTempDirectory "pkgTest" $ \dir ->
 renameAndCheck :: FilePath -> Path Abs Dir -> Path Abs Dir -> Expectation
 renameAndCheck name origPath newPath = do
     -- Check path moved
-    renamedPath <- Package.rename origPath newPath
+    (renamedPath, _) <- Package.rename origPath newPath
     renamedPath `shouldBe` newPath
 
     -- Check `config.yaml` has new name

--- a/shell/src/Luna/Shell/Command.hs
+++ b/shell/src/Luna/Shell/Command.hs
@@ -241,7 +241,11 @@ rename opts = MException.catch printRenameEx . MException.catch printPNFEx $ do
     canonicalSource <- getPath sourceDir
     canonicalTarget <- getPath targetDir
 
-    resultPath <- Package.rename canonicalSource canonicalTarget
+    (resultPath, err) <- Package.rename canonicalSource canonicalTarget
+
+    case err of
+        Nothing -> pure ()
+        Just ex -> liftIO . hPutStrLn stderr $ displayException ex
 
     putStrLn $ "Package renamed to " <> Path.fromAbsDir resultPath
 


### PR DESCRIPTION
### Pull Request Description
Change the error behaviour of the `Luna.Package.rename` function so that it doesn't throw an exception if it encounters an inability to remove the original directory. The error is instead bubbled up through the return value so that it can be logged.

This aims to help with [#1254](https://github.com/luna/luna-studio/issues/1254).

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md).
- [x] The code has been tested where possible.

