### PR TITLE
Ignore exceptions thrown by running ldconfig during linking

### DIFF
--- a/stdlib/src/Luna/Prim/DynamicLinker.hs
+++ b/stdlib/src/Luna/Prim/DynamicLinker.hs
@@ -111,7 +111,8 @@ loadLibrary namePattern = do
                <> [ extension | extension <- dynamicLibraryExtensions,
                                 not (null extension)
                   ]
-    linkerCache <- maybeToList <$> nativeLoadFromCache library
+    linkerCache <- maybeToList <$> nativeLoadFromCache library `catchAny`
+        const (return Nothing)
     extendedSearchPaths <- fmap concat . for nativeSearchPaths $ \path -> do
         files <- Dir.listDirectory path `catchAny` \_ -> return []
         let matchingFiles = filter (List.isInfixOf library) files


### PR DESCRIPTION
### Pull Request Description
Fixes erroneous behaviour when missing `ldconfig` would cause foreign function linking failure. If executing `ldconfig` results in an exception, it is ignored.

### Important Notes


### Checklist
Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md).
- [ ] The code has been tested where possible.

