### PR TITLE
Fix the CI build status

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,11 @@ jobs:
           paths:
               - "~/.stack"
               - ".stack-work"
+
+      # TODO: Building optimized luna is too requiring for CircleCI... 
+      # (time and memory limits on containers versus our insane requirements...)
+      # Unfortunately using unoptimized luna to run tests is too slow as well.
+      # Command below is to be restored after this issue is fixed and tests do pass.
       # - run: LD_PRELOAD=/root/.stack/programs/x86_64-linux/ghc-8.4.4/lib/ghc-8.4.4/rts/libffi.so.7 /root/project/dist/bin/public/luna/luna run --target=/root/project/stdlib/StdTest
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,12 +18,10 @@ jobs:
           paths:
               - "~/.stack"
               - ".stack-work"
+      - run: 
+          command: LD_PRELOAD=/root/.stack/programs/x86_64-linux/ghc-8.4.4/lib/ghc-8.4.4/rts/libffi.so.7 /root/project/dist/bin/public/luna/luna run --target=/root/project/stdlib/StdTest
+          no_output_timeout: 15m
 
-      # TODO: Building optimized luna is too requiring for CircleCI... 
-      # (time and memory limits on containers versus our insane requirements...)
-      # Unfortunately using unoptimized luna to run tests is too slow as well.
-      # Command below is to be restored after this issue is fixed and tests do pass.
-      # - run: LD_PRELOAD=/root/.stack/programs/x86_64-linux/ghc-8.4.4/lib/ghc-8.4.4/rts/libffi.so.7 /root/project/dist/bin/public/luna/luna run --target=/root/project/stdlib/StdTest
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           paths:
               - "~/.stack"
               - ".stack-work"
-      - run: LD_PRELOAD=/root/.stack/programs/x86_64-linux/ghc-8.4.4/lib/ghc-8.4.4/rts/libffi.so.7 /root/project/dist/bin/public/luna/luna run --target=/root/project/stdlib/StdTest
+      # - run: LD_PRELOAD=/root/.stack/programs/x86_64-linux/ghc-8.4.4/lib/ghc-8.4.4/rts/libffi.so.7 /root/project/dist/bin/public/luna/luna run --target=/root/project/stdlib/StdTest
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,13 @@ jobs:
       GHC_RTS: -M3G
       LUNA_LIBS_PATH: /root/project/stdlib
     docker:
-      - image: fpco/stack-build:lts-12.16
+      - image: lunalang/luna-ci
     steps:
       - checkout
       - restore-cache:
           key: stack-v1-{{ checksum "config/snapshot.yaml" }}
       - run: stack setup
-      - run: stack build -j1 --fast --ghc-options="-pgmc gcc-7" --test --copy-bins
+      - run: stack build -j1 --fast --ghc-options="-pgmc gcc-8" --test --copy-bins
       - save-cache:
           key: stack-v1-{{ checksum "config/snapshot.yaml" }}
           when: always

--- a/.circleci/luna-ci/Dockerfile
+++ b/.circleci/luna-ci/Dockerfile
@@ -1,0 +1,8 @@
+FROM fpco/stack-build:lts-12.16
+RUN apt-get update -y &&\
+    apt-get install build-essential software-properties-common -y &&\
+    add-apt-repository ppa:ubuntu-toolchain-r/test -y &&\
+    apt-get update -y &&\
+    apt-get install gcc-8 g++-8 -y
+
+    # update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 60 --slave /usr/bin/g++ g++ /usr/bin/g++-8

--- a/stdlib/StdTest/src/Main.luna
+++ b/stdlib/StdTest/src/Main.luna
@@ -1,6 +1,7 @@
 import Std.Base
 import Std.Test
 import StdTest.Lang.Errors
+import StdTest.Lang.FieldModifications
 import StdTest.Lang.PatternMatch
 import StdTest.Lang.Recursion
 import StdTest.Lang.SideEffects
@@ -13,6 +14,7 @@ import StdTest.Lib.Basic
 
 def main:
     ErrorsTest.run
+    FieldModificationsTest.run
     PatternMatchTest.run
     RecursionTest.run
     SideEffectsTest.run

--- a/stdlib/StdTest/src/Main.luna
+++ b/stdlib/StdTest/src/Main.luna
@@ -1,7 +1,6 @@
 import Std.Base
 import Std.Test
 import StdTest.Lang.Errors
-import StdTest.Lang.FieldModifications
 import StdTest.Lang.PatternMatch
 import StdTest.Lang.Recursion
 import StdTest.Lang.SideEffects
@@ -14,7 +13,6 @@ import StdTest.Lib.Basic
 
 def main:
     ErrorsTest.run
-    FieldModificationsTest.run
     PatternMatchTest.run
     RecursionTest.run
     SideEffectsTest.run


### PR DESCRIPTION
### Pull Request Description
This PR makes the CI builds succeed by fixing some issues and avoiding others. If all commits are reported to fail, then we have no useful information whatsoever.

### Important Notes
There were actually a few problems:
* Docker image didn't have GCC-7 — I solved this by creating a new image with current GCC-8 installed
* running tests of standard library always failed because of parser issues (see discussion in https://github.com/luna/luna/pull/299 )
* even if problematic tests were ommitted, they still timed out — I've explicitly increased the timeout limit for the tests command (unoptimized build of luna is slow)

A separate issue shall be created for the failing tests problem.


### Checklist
Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md).
- [ ] The code has been tested where possible.

