### PR TITLE
Fix CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
               - ".stack-work"
       - run: 
           command: LD_PRELOAD=/root/.stack/programs/x86_64-linux/ghc-8.4.4/lib/ghc-8.4.4/rts/libffi.so.7 /root/project/dist/bin/public/luna/luna run --target=/root/project/stdlib/StdTest
-          no_output_timeout: 15m
+          no_output_timeout: 45m
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - restore-cache:
           key: stack-v1-{{ checksum "config/snapshot.yaml" }}
       - run: stack setup
-      - run: stack build -j1 --fast --ghc-options="-pgmc gcc-8" --test --copy-bins
+      - run: stack build --ghc-options="-pgmc gcc-8" --test --copy-bins
       - save-cache:
           key: stack-v1-{{ checksum "config/snapshot.yaml" }}
           when: always


### PR DESCRIPTION
### Pull Request Description
This change follows the recent change to add `-fomit-interface-pragmas` by default to our compilation. It made our builds fast enough that we don't need `--fast` — and not having `--fast` allows some optimizations that make test run reasonably fast.
As the memory usage during build is greatly down, we can also remove `-j1` for further speedup.

I still left 45 min timeout on the tests job just to be safe — but tests should typically execute < 15 min.


### Important Notes
None.

### Checklist
Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md).
- [ ] The code has been tested where possible.

