### PR TITLE
Added fromRight and fromRight' fucntions.

### DIFF
--- a/lib/exception/src/Control/Monad/Exception.hs
+++ b/lib/exception/src/Control/Monad/Exception.hs
@@ -80,3 +80,11 @@ fromJust e = \case
     Nothing -> throw e
     Just a  -> return a
 {-# INLINE fromJust #-}
+
+fromRight :: MonadException e m => (l -> e) -> Either l r -> m r
+fromRight f = \case
+    Right r -> pure r
+    Left  l -> throw $ f l
+    
+fromRight' :: forall l m r. (MonadException SomeException m, Exception l) => Either l r -> m r
+fromRight' = fromRight toException


### PR DESCRIPTION
### Pull Request Description
This PR brings `fromRight` and `fromRight'` to the `luna-exception` package from its alternate incarnation at https://github.com/luna/luna-manager/blob/39d0c1279aea5315b403eb1734132eb4eea472b4/luna-manager/src/Control/Monad/Raise.hs#L95

I've only updated names to follow the new `fromSth` naming convention.

These function are used in the luna-manager codebase.

### Important Notes

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md).
- [x] The code has been tested where possible.

