### PR TITLE
Real.abs and Comples.modulus

### DIFF
--- a/stdlib/Std/src/Base.luna
+++ b/stdlib/Std/src/Base.luna
@@ -85,7 +85,7 @@ native class Real:
     # Tests whether `self` is equal to the argument.
     def == that: primRealEquals   self that
     # Absolute value.
-    def abs: if self < 0 then self.negate else self
+    def abs: if self < 0.0 then self.negate else self
 
     def toReal: self
 
@@ -259,7 +259,10 @@ class Complex:
         Complex r i
 
     # Complex number modulus.
-    def modulus: self.real*self.real + self.imaginary*self.imaginary
+    def modulus: self.modulusSquared.sqrt
+
+    # Complex number squared modulus.
+    def modulusSquared: self.real*self.real + self.imaginary*self.imaginary
 
 # Class representing boolean values
 class Bool:

--- a/stdlib/StdTest/src/Lib/Basic.luna
+++ b/stdlib/StdTest/src/Lib/Basic.luna
@@ -5,8 +5,10 @@ class BasicTest:
     def testUnaryMinus:
         TestSubject (-5) . should (be 5.negate)
     def intAbs:
+        TestSubject (5 . abs)          . should (be 5)
         TestSubject (5 . negate . abs) . should (be 5)
     def realAbs:
+        TestSubject (5.0 . abs)          . should (be 5.0)
         TestSubject (5.0 . negate . abs) . should (be 5.0)
     def complexModulus:
         TestSubject (Complex 5.0 4.0 . modulusSquared) . should (be 41.0)

--- a/stdlib/StdTest/src/Lib/Basic.luna
+++ b/stdlib/StdTest/src/Lib/Basic.luna
@@ -4,6 +4,19 @@ import Std.Test
 class BasicTest:
     def testUnaryMinus:
         TestSubject (-5) . should (be 5.negate)
+    def intAbs:
+        TestSubject (5 . negate . abs) . should (be 5)
+    def realAbs:
+        TestSubject (5.0 . negate . abs) . should (be 5.0)
+    def complexModulus:
+        TestSubject (Complex 5.0 4.0 . modulusSquared) . should (be 41.0)
+        TestSubject (Complex 5.0 0.0 . modulusSquared) . should (be 25.0)
+        TestSubject (Complex 0.0 5.0 . modulusSquared) . should (be 25.0)
+        TestSubject (Complex 5.0 0.0 . modulus) . should (be 5.0)
+        TestSubject (Complex 0.0 5.0 . modulus) . should (be 5.0)
 
     def run:
         Test.specify "unary negation delegates to `negate` method" self.testUnaryMinus
+        Test.specify "Int.abs" self.intAbs
+        Test.specify "Real.abs" self.realAbs
+        Test.specify "Complex.modulus" self.complexModulus


### PR DESCRIPTION
### Pull Request Description
1. `Real.abs` didn't work because self couldn't be compared against Integer literal 0.
2. `Complex.modulus` returned modulus squared. I have added sqrt call, and `modulusSquared` method for previous behaviour.

### Important Notes

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md).
- [x] The code has been tested where possible.

