### PR TITLE
Library env vars

### DIFF
--- a/package/src/Luna/Package/Env.hs
+++ b/package/src/Luna/Package/Env.hs
@@ -1,0 +1,32 @@
+module Luna.Package.Env where
+
+import Prologue
+
+import qualified Data.Char          as Char
+import qualified System.Environment as Env
+
+import Luna.IR (Name)
+
+packageEnvVarPrefix :: String
+packageEnvVarPrefix = "LUNA_LIBRARY_"
+
+-- | This function translates a name like MyLibrary to an underscored
+--   environment variable name: LUNA_LIBRARY_MY_LIBRARY.
+packageNameToEnvVarName :: Text -> Text
+packageNameToEnvVarName txt = convert $ packageEnvVarPrefix <> envName where
+    envName = Char.toUpper <$> intercalate "_" wordsByCapitalization
+    wordsByCapitalization = reverse $ split "" (convert txt)
+    split []       []             = []
+    split prevWord []             = [reverse prevWord]
+    split prevWord (char : chars) = if Char.isUpper char
+        then let
+            recur = split [char] chars
+            in if null prevWord then recur else reverse prevWord : recur
+        else split (char : prevWord) chars
+
+setLibraryVar :: MonadIO m => Name -> FilePath -> m ()
+setLibraryVar name path = liftIO $ Env.setEnv varName path where
+    varName = convert . packageNameToEnvVarName . convert $ name
+
+setLibraryVars :: MonadIO m => [(Name, FilePath)] -> m ()
+setLibraryVars = traverse_ $ uncurry setLibraryVar

--- a/package/src/Luna/Package/Environment.hs
+++ b/package/src/Luna/Package/Environment.hs
@@ -1,4 +1,4 @@
-module Luna.Package.Env where
+module Luna.Package.Environment where
 
 import Prologue
 

--- a/shell/src/Luna/Shell/Interpret.hs
+++ b/shell/src/Luna/Shell/Interpret.hs
@@ -8,7 +8,7 @@ import qualified Data.Graph.Data.Graph.Class         as Graph
 import qualified Data.Map                            as Map
 import qualified Luna.IR                             as IR
 import qualified Luna.Package                        as Package
-import qualified Luna.Package.Env                    as PackageEnv
+import qualified Luna.Package.Environment            as PackageEnv
 import qualified Luna.Package.Structure.Name         as Package
 import qualified Luna.Pass.Data.Stage                as TC
 import qualified Luna.Pass.Flow.ProcessUnits         as ProcessUnits

--- a/shell/src/Luna/Shell/Interpret.hs
+++ b/shell/src/Luna/Shell/Interpret.hs
@@ -8,6 +8,7 @@ import qualified Data.Graph.Data.Graph.Class         as Graph
 import qualified Data.Map                            as Map
 import qualified Luna.IR                             as IR
 import qualified Luna.Package                        as Package
+import qualified Luna.Package.Env                    as PackageEnv
 import qualified Luna.Package.Structure.Name         as Package
 import qualified Luna.Pass.Data.Stage                as TC
 import qualified Luna.Pass.Flow.ProcessUnits         as ProcessUnits
@@ -97,10 +98,12 @@ interpretWithMain name sourcesMap = Graph.encodeAndEval @TC.Stage
 file :: (InterpreterMonad m) => Path Abs File -> Path Abs Dir -> m ()
 file filePath stdlibPath = liftIO $ Directory.withCurrentDirectory fileFP $ do
     fileSources <- Package.fileSourcePaths filePath stdlibPath
+    includedImports <- Package.includedLibs stdlibPath
 
     let fileName = convertVia @Name.Name . FilePath.dropExtension
             . Path.fromRelFile $ Path.filename filePath
 
+    PackageEnv.setLibraryVars includedImports
     liftIO $ interpretWithMain fileName fileSources
 
     where fileFP = Path.fromAbsDir $ Path.parent filePath
@@ -118,6 +121,7 @@ package pkgPath stdlibPath = liftIO . Directory.withCurrentDirectory pkgDir $ do
         mainFileName = (convert $ Package.getPackageName packageRoot) <> "."
             <> Package.mainFileName
 
+    PackageEnv.setLibraryVars packageImports
     liftIO $ interpretWithMain mainFileName pkgSrcMap
 
     where pkgDir = Path.fromAbsDir pkgPath

--- a/stdlib/Std/src/Base.luna
+++ b/stdlib/Std/src/Base.luna
@@ -1002,8 +1002,11 @@ native class Text:
     def addPathSegment segment: self + pathSeparator + segment
 
     # Append a path segment to the given `Text`. The new segment will use
-    # a path separator specific for current platform, making it the safest
-    # way of consturcting paths.
+    # a path separator specific for current platform.
+    # This is the recommended way of constructing paths.
+    #
+    # `segment`: Path segment to be appended to `self`.
+    # `returns`: Path resulting from appending `segment` to `self`.
     def / segment: self.addPathSegment segment
 
     def toLQueryValue: ValText self

--- a/stdlib/Std/src/Base.luna
+++ b/stdlib/Std/src/Base.luna
@@ -1000,6 +1000,10 @@ native class Text:
         Nothing:  errorStr ("Could not convert " + self + " to a Real")
 
     def addPathSegment segment: self + pathSeparator + segment
+
+    # Append a path segment to the given `Text`. The new segment will use
+    # a path separator specific for current platform, making it the safest
+    # way of consturcting paths.
     def / segment: self.addPathSegment segment
 
     def toLQueryValue: ValText self
@@ -3669,13 +3673,27 @@ class TableHandle:
     def at name:
         ColumnRef name
 
+# This class provides a way of accessing files inside available packages.
+# It's particularly useful for internal data, data samples etc.
 class Package:
     def _envVarName: primPackageNameToEnvVarName
 
+    # Get the root path for a given package.
+    # E.g. `Package.root 'Std'` will point to the location
+    # of the standard library inside a Luna distribution.
     def root name:
         mayPath = primLookupEnv $ self._envVarName name
         mayPath.withDefault $ throw $ 'Package ' + name + ' not found.'
 
+    # Get the sample data directory for a given package.
+    # Samples are, by convention, data files that can be used to demonstrate
+    # capabilities of the library.
+    # They are located in the `LIBRARY_ROOT/samples` directory.
+    # For example, the path to `iris.csv` sample dataset from the
+    # `Dataframes` package can be accessed as:
+    # ```
+    # Package.samples 'Dataframes' / 'iris.csv'
+    # ```
     def samples name:
         self.root name / 'samples'
 

--- a/stdlib/Std/src/Base.luna
+++ b/stdlib/Std/src/Base.luna
@@ -1000,6 +1000,7 @@ native class Text:
         Nothing:  errorStr ("Could not convert " + self + " to a Real")
 
     def addPathSegment segment: self + pathSeparator + segment
+    def / segment: self.addPathSegment segment
 
     def toLQueryValue: ValText self
 
@@ -3667,3 +3668,14 @@ class Predicate a:
 class TableHandle:
     def at name:
         ColumnRef name
+
+class Package:
+    def _envVarName: primPackageNameToEnvVarName
+
+    def root name:
+        mayPath = primLookupEnv $ self._envVarName name
+        mayPath.withDefault $ throw $ 'Package ' + name + ' not found.'
+
+    def samples name:
+        self.root name / 'samples'
+

--- a/stdlib/src/Luna/Prim/Package.hs
+++ b/stdlib/src/Luna/Prim/Package.hs
@@ -1,0 +1,21 @@
+module Luna.Prim.Package where
+
+import Prologue
+
+import qualified Data.Map                    as Map
+import qualified Luna.IR                     as IR
+import qualified Luna.Package.Env            as PackageEnv
+import qualified Luna.Pass.Sourcing.Data.Def as Def
+import qualified Luna.Runtime                as Runtime
+import qualified Luna.Std.Builder            as Builder
+
+import Data.Map (Map)
+
+exports
+    :: forall graph m. (Builder.StdBuilder graph m) => m (Map IR.Name Def.Def)
+exports = do
+    primPackageNameToEnvVarName <- Builder.makeFunction @graph
+        (flip Runtime.toValue PackageEnv.packageNameToEnvVarName)
+        [Builder.textLT]
+        Builder.textLT
+    pure $ Map.fromList [("primPackageNameToEnvVarName", primPackageNameToEnvVarName)]

--- a/stdlib/src/Luna/Prim/Package.hs
+++ b/stdlib/src/Luna/Prim/Package.hs
@@ -4,7 +4,7 @@ import Prologue
 
 import qualified Data.Map                    as Map
 import qualified Luna.IR                     as IR
-import qualified Luna.Package.Env            as PackageEnv
+import qualified Luna.Package.Environment    as PackageEnv
 import qualified Luna.Pass.Sourcing.Data.Def as Def
 import qualified Luna.Runtime                as Runtime
 import qualified Luna.Std.Builder            as Builder

--- a/stdlib/src/Luna/Prim/Package.hs
+++ b/stdlib/src/Luna/Prim/Package.hs
@@ -18,4 +18,5 @@ exports = do
         (flip Runtime.toValue PackageEnv.packageNameToEnvVarName)
         [Builder.textLT]
         Builder.textLT
-    pure $ Map.fromList [("primPackageNameToEnvVarName", primPackageNameToEnvVarName)]
+    pure $ Map.fromList
+        [("primPackageNameToEnvVarName", primPackageNameToEnvVarName)]

--- a/syntax/text/parser/src/Luna/Syntax/Text/Parser/Hardcoded.hs
+++ b/syntax/text/parser/src/Luna/Syntax/Text/Parser/Hardcoded.hs
@@ -44,8 +44,10 @@ hardcodePrecRelMap = do
     Prec.writeRel EQ ("-"     :: Name) (Name.uminus :: Name)
     Prec.writeRel EQ ("%"     :: Name) ("*"         :: Name)
     Prec.writeRel EQ ("/"     :: Name) ("*"         :: Name)
+    Prec.writeRel EQ ("*"     :: Name) ("/"         :: Name)
 
     Assoc.write Assoc.Right (Name.lam :: Name)
+    Assoc.write Assoc.Right ("$"      :: Name)
 
 
 hardcodeMultiNames :: State.Monad Scope m => m ()


### PR DESCRIPTION
### Pull Request Description
This introduces a way for Luna code to peek into the files exposed by available libraries. It is needed for providing sample data to libraries, making it easier for users to try out different capabilities.

### Important Notes
The implementation exports specific environment variables during evaluation of Luna code.
For a package named `ExamplePackage`, there will appear a `LUNA_LIBRARY_EXAMPLE_PACKAGE` environment variable, set to the absolute location of the root of `ExamplePackage`.
There's also a Luna helper allowing to access these without thinking about env vars:
```
Package.root 'ExamplePackage' # returns the absolute path to ExamplePackage
Package.samples 'ExamplePackage' # returns the absolute path to `samples` subdirectory of ExamplePackage
```
This allows to access samples e.g. like this:
```
Table.read $ Package.samples "Dataframes" / "iris.csv"
```

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md).
- [x] The code has been tested where possible.

