### PR TITLE
Prevent CI running twice on Pull Requests

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -3,6 +3,7 @@
 trigger:
   branches:
     include: [ "*" ]
+  pr: none
   paths:
     exclude:
       - .github/*

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -3,12 +3,13 @@
 trigger:
   branches:
     include: [ "*" ]
-  pr: none
   paths:
     exclude:
       - .github/*
       - README.md
       - doc/*
+
+pr: none
 
 jobs:
 - job: Ubuntu


### PR DESCRIPTION
### Pull Request Description
Currently CI runs twice on pull requests to this repo due to overlapping triggers. This is an attempt to prevent this from happening. 

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] The code conforms to the [Luna Style Guide](https://github.com/luna/wiki/blob/master/code-style/01.general.md).
- [x] The code has been tested where possible.

